### PR TITLE
Removing publish=false from TOML to prepare for impending crates / bioconda release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = [
     "Nils Homer <nils@fulcrumgenomics.com>"
 ]
 name = "fqtk"
-publish = false
 version = "0.1.0"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
This modifies the TOML to allow for publishing up to crates.