### PR TITLE
Add 'version' arg to command line derivations

### DIFF
--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -492,6 +492,7 @@ impl DemuxMetric {
 /// ```
 ///
 #[derive(Parser, Debug)]
+#[command(version)]
 pub(crate) struct Demux {
     /// One or more input fastq files each corresponding to a sequencing (e.g. R1, I1).
     #[clap(long, short = 'i', required = true, num_args = 1..)]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -20,6 +20,7 @@ struct Args {
 
 #[enum_dispatch(Command)]
 #[derive(Parser, Debug)]
+#[command(version)]
 enum Subcommand {
     Demux(Demux),
 }


### PR DESCRIPTION
This adds the arg `--version` to the fqtk command line, which is apparently a requirement for adding it to nf-core, etc.