### PR TITLE
feat: allow Ns in the sample barcode

### DIFF
--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -468,7 +468,7 @@ impl DemuxMetric {
 ///
 /// An observed barcode matches an expected barcocde if all the following are true:
 /// 1. The number of mismatches (edits/substitutions) is less than or equal to the maximum 
-///.   mismatches (see `--max-mismatches`).
+///    mismatches (see `--max-mismatches`).
 /// 2. The difference between number of mismatches in the best and second best barcodes is greater
 ///    than or equal to the minimum mismatch delta (`--min-mismatch-delta`).
 /// The expected barcode sequence may contains Ns, which are not counted as mismatches regardless

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -466,6 +466,15 @@ impl DemuxMetric {
 /// molecular identifiers from each read.  The observed sample barcode will be matched to the
 /// sample barcodes extracted from the bases in the sample metadata and associated read structures.
 ///
+/// An observed barcode matches an expected barcocde if all the following are true:
+/// 1. The number of mismatches (edits/substitutions) is less than or equal to the maximum 
+///.   mismatches (see `--max-mismatches`).
+/// 2. The difference between number of mismatches in the best and second best barcodes is greater
+///    than or equal to the minimum mismatch delta (`--min-mismatch-delta`).
+/// The expected barcode sequence may contains Ns, which are not counted as mismatches regardless
+/// of the observed base (e.g. the expected barcode `AAN` will have zero mismatches relative to
+/// both the observed barcodes `AAA` and `AAN`).
+///
 /// ## Outputs
 ///
 /// All outputs are generated in the provided `--output` directory.  For each sample plus the

--- a/src/lib/barcode_matching.rs
+++ b/src/lib/barcode_matching.rs
@@ -1,13 +1,9 @@
+use super::byte_is_nocall;
 use ahash::HashMap as AHashMap;
 use ahash::HashMapExt;
 use bstr::{BString, ByteSlice};
 
 const STARTING_CACHE_SIZE: usize = 1_000_000;
-
-/// Checks whether a given u8 byte is a "No-call"-ed base, signified by the bytes 'N', 'n' and '.'
-fn byte_is_nocall(byte: u8) -> bool {
-    byte == b'N' || byte == b'n' || byte == b'.'
-}
 
 /// The struct that contains the info related to the best and next best sample barcode match.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -177,24 +173,6 @@ mod tests {
     fn test_barcode_matcher_fails_if_empty_sample_barcode_provided(#[case] use_cache: bool) {
         let sample_barcodes = vec!["AGCT", ""];
         let _matcher = BarcodeMatcher::new(&sample_barcodes, 2, 1, use_cache);
-    }
-
-    // ############################################################################################
-    // Test byte_is_no_call
-    // ############################################################################################
-    #[test]
-    fn test_byte_is_no_call() {
-        assert!(byte_is_nocall(b'N'));
-        assert!(byte_is_nocall(b'n'));
-        assert!(byte_is_nocall(b'.'));
-        assert!(!byte_is_nocall(b'A'));
-        assert!(!byte_is_nocall(b'C'));
-        assert!(!byte_is_nocall(b'G'));
-        assert!(!byte_is_nocall(b'T'));
-        assert!(!byte_is_nocall(b'a'));
-        assert!(!byte_is_nocall(b'c'));
-        assert!(!byte_is_nocall(b'g'));
-        assert!(!byte_is_nocall(b't'));
     }
 
     // ############################################################################################

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,2 +1,53 @@
 pub mod barcode_matching;
 pub mod samples;
+
+/// Checks whether a given u8 byte is a "No-call"-ed base, signified by the bytes 'N', 'n' and '.'
+fn byte_is_nocall(byte: u8) -> bool {
+    byte == b'N' || byte == b'n' || byte == b'.'
+}
+
+/// Checks whether a provided byte is an A, G, C, or T.
+fn is_valid_base(byte: u8) -> bool {
+    byte == b'A' || byte == b'C' || byte == b'G' || byte == b'T' || byte_is_nocall(byte)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ############################################################################################
+    // Test byte_is_no_call
+    // ############################################################################################
+    #[test]
+    fn test_byte_is_no_call() {
+        assert!(byte_is_nocall(b'N'));
+        assert!(byte_is_nocall(b'n'));
+        assert!(byte_is_nocall(b'.'));
+        assert!(!byte_is_nocall(b'A'));
+        assert!(!byte_is_nocall(b'C'));
+        assert!(!byte_is_nocall(b'G'));
+        assert!(!byte_is_nocall(b'T'));
+        assert!(!byte_is_nocall(b'a'));
+        assert!(!byte_is_nocall(b'c'));
+        assert!(!byte_is_nocall(b'g'));
+        assert!(!byte_is_nocall(b't'));
+    }
+
+    // ############################################################################################
+    // Test is_valid_base
+    // ############################################################################################
+    #[test]
+    fn test_is_valid_base() {
+        assert!(is_valid_base(b'N'));
+        assert!(is_valid_base(b'n'));
+        assert!(is_valid_base(b'.'));
+        assert!(!is_valid_base(b'a'));
+        assert!(!is_valid_base(b'c'));
+        assert!(!is_valid_base(b'g'));
+        assert!(!is_valid_base(b't'));
+        assert!(is_valid_base(b'A'));
+        assert!(is_valid_base(b'C'));
+        assert!(is_valid_base(b'G'));
+        assert!(is_valid_base(b'T'));
+    }
+}

--- a/src/lib/samples.rs
+++ b/src/lib/samples.rs
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_sample_non_agct_bases_in_barcode() {
+    fn test_new_sample_non_agct_bases_in_barcode_allowed() {
         let name = "s_1_example_name".to_owned();
         let barcode = "GATTANN".to_owned();
         let ordinal = 0;

--- a/src/lib/samples.rs
+++ b/src/lib/samples.rs
@@ -1,3 +1,4 @@
+use super::is_valid_base;
 use anyhow::Result;
 use fgoxide::io::DelimFile;
 use itertools::Itertools;
@@ -9,11 +10,6 @@ use std::fmt::{self, Display};
 use std::path::Path;
 
 const DEFAULT_FILE_DELIMETER: u8 = b'\t';
-
-/// Checks whether a provided byte is an A, G, C, or T.
-fn is_valid_base(byte: u8) -> bool {
-    byte == b'A' || byte == b'C' || byte == b'G' || byte == b'T'
-}
 
 /// Struct for describing a single sample and metadata associated with that sample.
 #[derive(Clone, Deserialize, Debug, PartialEq, Eq)]
@@ -207,6 +203,14 @@ mod tests {
         assert!(samples_metadata.samples[1].barcode == "CATGCTA");
     }
 
+    #[test]
+    fn test_new_sample_non_agct_bases_in_barcode() {
+        let name = "s_1_example_name".to_owned();
+        let barcode = "GATTANN".to_owned();
+        let ordinal = 0;
+        let _sample = Sample::new(ordinal, name, barcode);
+    }
+
     // ############################################################################################
     // Test [`SampleGroup::from_file`] - Expected to panic
     // ############################################################################################
@@ -266,24 +270,6 @@ mod tests {
     }
 
     // ############################################################################################
-    // Test is_valid_base
-    // ############################################################################################
-    #[test]
-    fn test_is_valid_base() {
-        assert!(!is_valid_base(b'N'));
-        assert!(!is_valid_base(b'n'));
-        assert!(!is_valid_base(b'.'));
-        assert!(!is_valid_base(b'a'));
-        assert!(!is_valid_base(b'c'));
-        assert!(!is_valid_base(b'g'));
-        assert!(!is_valid_base(b't'));
-        assert!(is_valid_base(b'A'));
-        assert!(is_valid_base(b'C'));
-        assert!(is_valid_base(b'G'));
-        assert!(is_valid_base(b'T'));
-    }
-
-    // ############################################################################################
     // Test [`Sample::new`] - Expected to pass
     // ############################################################################################
     #[test]
@@ -317,15 +303,6 @@ mod tests {
     fn test_new_sample_fail2_empty_barcode() {
         let name = "s_1_example_name".to_owned();
         let barcode = String::new();
-        let ordinal = 0;
-        let _sample = Sample::new(ordinal, name, barcode);
-    }
-
-    #[test]
-    #[should_panic(expected = "All sample barcode bases must be one of A, C, G, or T")]
-    fn test_new_sample_fail3_non_agct_bases_in_barcode() {
-        let name = "s_1_example_name".to_owned();
-        let barcode = "GATTANN".to_owned();
         let ordinal = 0;
         let _sample = Sample::new(ordinal, name, barcode);
     }


### PR DESCRIPTION
This is also useful if the barcodes are of different length, so we can pad the shorter barcodes with Ns


#29