### PR TITLE
Improved `fqtk demux --help` output readability

### DIFF
--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -542,7 +542,7 @@ impl DemuxMetric {
 /// structures) of one of the types supplied to `--output-types`.  FASTQ files have names
 /// of the format:
 ///
-/// ```
+/// ```bash
 /// {sample_id}.{segment_type}{read_num}.fq.gz
 /// ```
 ///
@@ -559,7 +559,7 @@ impl DemuxMetric {
 /// reading a sample barcode, as well as an in-line 8bp sample barcode in read one, the command
 /// line would be:
 ///
-/// ```
+/// ```bash
 /// fqtk demux \
 ///     --inputs r1.fq.gz i1.fq.gz i2.fq.gz r2.fq.gz \
 ///     --read-structures 8B92T 8B 8B 100T \
@@ -569,6 +569,7 @@ impl DemuxMetric {
 ///
 #[derive(Parser, Debug)]
 #[command(version)]
+#[clap(verbatim_doc_comment)]
 pub(crate) struct Demux {
     /// One or more input fastq files each corresponding to a sequencing (e.g. R1, I1).
     #[clap(long, short = 'i', required = true, num_args = 1..)]


### PR DESCRIPTION
 I looked into parsing MarkDown in Rust for terminal output, and the two options that might make sense are [`pulldown-cmark-mdcat`](https://docs.rs/pulldown-cmark-mdcat/2.2.0/pulldown_cmark_mdcat/) and [`termimad`](https://docs.rs/termimad/latest/termimad/). 

However, since the help text is in a documentation string (currently parsed and added to `--help` by `clap`), I decided not to add a dependency and move things around. It looks like it may be a while before clap adds MarkDown support (https://github.com/clap-rs/clap/issues/2389), but a simple single-line workaround fixes the newline issue around Markdown lists and code, which IMO was the main readability issue.