### PR TITLE
feat: minor speedups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,19 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -220,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -410,7 +397,6 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 name = "fqtk"
 version = "0.3.2-rc.1"
 dependencies = [
- "ahash",
  "anyhow",
  "bstr 1.12.1",
  "clap",
@@ -428,6 +414,7 @@ dependencies = [
  "rand_chacha",
  "read-structure",
  "rstest",
+ "rustc-hash",
  "seq_io",
  "serde",
  "serde-aux",
@@ -671,9 +658,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdeflate-sys"
@@ -695,12 +682,11 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -742,9 +728,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -1071,6 +1057,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,12 +1381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ path = "src/bin/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ahash = "0.8.12"
 anyhow = "1.0.102"
 bstr = "1.12.1"
 clap = { version = "4.6.0", features = ["derive"] }
@@ -46,6 +45,7 @@ rand = "0.9"
 rand_chacha = "0.9"
 read-structure = "0.2.0"
 rstest = "0.26.1"
+rustc-hash = "2.1.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde-aux = "4.7.0"
 seq_io = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Options:
           [default: 2]
 
   -t, --threads <THREADS>
-          The number of threads to use. Cannot be less than 3
+          The number of threads to use. Cannot be less than 5
 
           [default: 8]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -16,6 +16,7 @@ use read_structure::SegmentType;
 use seq_io::fastq::Reader as FastqReader;
 use seq_io::fastq::Record;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::fs::File;
@@ -36,6 +37,10 @@ type VecOfReaders = Vec<Box<dyn BufRead + Send>>;
 type SegmentIter<'a> = Filter<Iter<'a, FastqSegment>, fn(&&FastqSegment) -> bool>;
 
 const BUFFER_SIZE: usize = 1024 * 1024;
+
+/// Buffer capacity for each per-output `.fq.gz` writer.  Sized to roughly one BGZF block so
+/// each flush corresponds to a single write syscall.
+const OUTPUT_WRITER_BUFFER_SIZE: usize = 64 * 1024;
 
 /// The bases and qualities associated with a segment of a FASTQ record.
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -93,6 +98,20 @@ impl ReadSet {
     const SPACE: u8 = b' ';
     const COLON: u8 = b':';
     const PLUS: u8 = b'+';
+    /// ASCII digit table; indexing it avoids a `format!` allocation for the common
+    /// single-digit read-number case (see [`Self::write_read_num`]).
+    const READ_NUMBERS: &[u8] = b"0123456789";
+
+    /// Writes `read_num` as ASCII to `writer`, using a single-byte fast path for 0-9 and
+    /// falling back to `write!` for larger values.
+    fn write_read_num<W: Write>(writer: &mut W, read_num: usize) -> Result<()> {
+        if read_num < Self::READ_NUMBERS.len() {
+            writer.write_all(&[Self::READ_NUMBERS[read_num]])?;
+        } else {
+            write!(writer, "{}", read_num)?;
+        }
+        Ok(())
+    }
 
     /// Produces an iterator over references to the template segments stored in this ``ReadSet``.
     fn template_segments(&self) -> SegmentIter {
@@ -117,9 +136,26 @@ impl ReadSet {
         self.segments.iter().filter(|s| s.segment_type == SegmentType::CellularBarcode)
     }
 
-    /// Generates the sample barcode sequence for this read set and returns it as a Vec of bytes.
-    fn sample_barcode_sequence(&self) -> Vec<u8> {
-        self.sample_barcode_segments().flat_map(|s| &s.seq).copied().collect()
+    /// Generates the sample barcode sequence for this read set as a borrow when possible.
+    /// Returns `Cow::Borrowed(&seg.seq)` for the common single-segment case (zero allocation),
+    /// otherwise concatenates segment bytes into a new `Vec<u8>`.
+    fn sample_barcode_sequence(&self) -> Cow<'_, [u8]> {
+        let mut iter = self.sample_barcode_segments();
+        let Some(first) = iter.next() else {
+            return Cow::Owned(Vec::new());
+        };
+        match iter.next() {
+            None => Cow::Borrowed(&first.seq),
+            Some(second) => {
+                let mut bytes = Vec::with_capacity(first.seq.len() + second.seq.len());
+                bytes.extend_from_slice(&first.seq);
+                bytes.extend_from_slice(&second.seq);
+                for seg in iter {
+                    bytes.extend_from_slice(&seg.seq);
+                }
+                Cow::Owned(bytes)
+            }
+        }
     }
 
     /// Combines ``ReadSet`` structs together into a single ``ReadSet``
@@ -219,7 +255,8 @@ impl ReadSet {
             None => {
                 // If no pre-existing comment, assume the read is a passing filter, non-control
                 // read and generate a comment for it (sample barcode is added below).
-                write!(writer, "{}:N:0:", read_num)?;
+                Self::write_read_num(writer, read_num)?;
+                writer.write_all(b":N:0:")?;
             }
             Some(chars) => {
                 // Else check it's a 4-part name... fix the read number at the front and
@@ -245,7 +282,8 @@ impl ReadSet {
                         &chars[first_colon_idx + 1..chars.len()]
                     };
 
-                    write!(writer, "{}:", read_num)?;
+                    Self::write_read_num(writer, read_num)?;
+                    writer.write_all(&[Self::COLON])?;
                     writer.write_all(remainder)?;
 
                     if *remainder.last().unwrap() != Self::COLON {
@@ -634,7 +672,7 @@ pub(crate) struct Demux {
     #[clap(long, short = 'd', default_value = "2")]
     min_mismatch_delta: usize,
 
-    /// The number of threads to use. Cannot be less than 3.
+    /// The number of threads to use. Cannot be less than 5.
     #[clap(long, short = 't', default_value = "8")]
     threads: usize,
 
@@ -683,9 +721,12 @@ impl Demux {
                 read_structures.iter().map(|s| s.segments_by_type(*output_type).count()).sum();
 
             for idx in 1..=segment_count {
-                output_type_writers.push(BufWriter::new(File::create(
-                    output_dir.join(format!("{}.{}{}.fq.gz", prefix, file_type_code, idx)),
-                )?));
+                output_type_writers.push(BufWriter::with_capacity(
+                    OUTPUT_WRITER_BUFFER_SIZE,
+                    File::create(
+                        output_dir.join(format!("{}.{}{}.fq.gz", prefix, file_type_code, idx)),
+                    )?,
+                ));
             }
 
             match output_type {
@@ -1012,6 +1053,19 @@ mod tests {
     use tempfile::TempDir;
 
     const SAMPLE1_BARCODE: &str = "GATTGGG";
+
+    #[rstest]
+    #[case(0, "0")]
+    #[case(1, "1")]
+    #[case(9, "9")]
+    #[case(10, "10")]
+    #[case(123, "123")]
+    #[case(99_999, "99999")]
+    fn test_write_read_num(#[case] read_num: usize, #[case] expected: &str) {
+        let mut buf: Vec<u8> = Vec::new();
+        ReadSet::write_read_num(&mut buf, read_num).unwrap();
+        assert_eq!(str::from_utf8(&buf).unwrap(), expected);
+    }
 
     /// Given a record name prefix and a slice of bases for a set of records, returns the contents
     /// of a FASTQ file as a vec of Strings, one string per line of the FASTQ.
@@ -1993,7 +2047,7 @@ mod tests {
             vec!["AAAAAAA", &SAMPLE1_BARCODE[0..7]], // barcode too short
             vec!["CCCCCCC", SAMPLE1_BARCODE],        // barcode the correct length
             vec!["", SAMPLE1_BARCODE],               // template basese too short
-            vec!["G", SAMPLE1_BARCODE],              // barcode the correct length
+            vec!["G", SAMPLE1_BARCODE],
         ];
 
         let input_files = vec![
@@ -2029,7 +2083,7 @@ mod tests {
             vec!["AAAAAAA", &SAMPLE1_BARCODE[0..7]], // barcode too short
             vec!["CCCCCCC", SAMPLE1_BARCODE],        // barcode the correct length
             vec!["", SAMPLE1_BARCODE],               // template basese too short
-            vec!["G", SAMPLE1_BARCODE],              // barcode the correct length
+            vec!["G", SAMPLE1_BARCODE],
         ];
 
         let input_files = vec![
@@ -2200,7 +2254,7 @@ mod tests {
     // ############################################################################################
 
     #[test]
-    fn test_sample_barcode_sequence() {
+    fn test_sample_barcode_sequence_multi_segment_owns() {
         let segments = vec![
             seg("AGCT".as_bytes(), SegmentType::Template),
             seg("GATA".as_bytes(), SegmentType::SampleBarcode),
@@ -2209,8 +2263,30 @@ mod tests {
         ];
 
         let read_set = read_set(segments);
+        let bc = read_set.sample_barcode_sequence();
+        assert_eq!(bc.as_ref(), b"GATACAC");
+        assert!(matches!(bc, Cow::Owned(_)));
+    }
 
-        assert_eq!(read_set.sample_barcode_sequence(), "GATACAC".as_bytes().to_owned());
+    #[test]
+    fn test_sample_barcode_sequence_single_segment_borrows() {
+        let segments = vec![
+            seg("AGCT".as_bytes(), SegmentType::Template),
+            seg("GATTACA".as_bytes(), SegmentType::SampleBarcode),
+        ];
+
+        let read_set = read_set(segments);
+        let bc = read_set.sample_barcode_sequence();
+        assert_eq!(bc.as_ref(), b"GATTACA");
+        assert!(matches!(bc, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn test_sample_barcode_sequence_no_segments_returns_empty() {
+        let segments = vec![seg("AGCT".as_bytes(), SegmentType::Template)];
+        let read_set = read_set(segments);
+        let bc = read_set.sample_barcode_sequence();
+        assert!(bc.is_empty());
     }
 
     #[test]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 extern crate core;
 
 pub mod commands;

--- a/src/lib/barcode_matching.rs
+++ b/src/lib/barcode_matching.rs
@@ -6,8 +6,7 @@ use crate::encode;
 use super::byte_is_nocall;
 use super::samples::Sample;
 use crate::bitenc::BitEnc;
-use ahash::HashMap as AHashMap;
-use ahash::HashMapExt;
+use rustc_hash::FxHashMap;
 
 const STARTING_CACHE_SIZE: usize = 1_000_000;
 
@@ -38,10 +37,8 @@ pub struct BarcodeMatcher {
     /// The minimum difference between number of mismatches in the best and second best barcodes
     /// for a barcode to be considered a match.
     min_mismatch_delta: u8,
-    /// If true will attempt to use the cache when matching.
-    use_cache: bool,
-    /// Caching struct for storing results of previous matches
-    cache: AHashMap<Vec<u8>, BarcodeMatch>,
+    /// Cache of previous matches; `None` disables caching, `Some(map)` enables it.
+    cache: Option<FxHashMap<Vec<u8>, BarcodeMatch>>,
 }
 
 impl BarcodeMatcher {
@@ -74,37 +71,25 @@ impl BarcodeMatcher {
             max_ns_in_barcodes = max_ns_in_barcodes.max(num_ns);
             sample_barcodes.push(encode(bytes));
         }
+        let cache = use_cache
+            .then(|| FxHashMap::with_capacity_and_hasher(STARTING_CACHE_SIZE, Default::default()));
         Self {
             samples: modified_samples,
             sample_barcodes,
             max_ns_in_barcodes,
             max_mismatches,
             min_mismatch_delta,
-            use_cache,
-            cache: AHashMap::with_capacity(STARTING_CACHE_SIZE),
+            cache,
         }
     }
 
-    /// Counts the number of bases that differ between two byte arrays.
+    /// Counts the number of bases that differ between two equal-length encoded byte arrays.
+    /// Callers must ensure lengths match (validated once in [`Self::assign_internal`]).
     fn count_mismatches(
         observed_bases: &BitEnc,
         expected_bases: &BitEnc,
-        sample: &Sample,
         max_mismatches: u8,
     ) -> u8 {
-        if observed_bases.nr_symbols() != expected_bases.nr_symbols() {
-            let observed_string = decode(observed_bases);
-            assert_eq!(
-                observed_bases.nr_symbols(),
-                expected_bases.nr_symbols(),
-                "Read barcode ({}) length ({}) differs from expected barcode ({}) length ({}) for sample {}",
-                observed_string,
-                observed_bases.nr_symbols(),
-                sample.barcode,
-                expected_bases.nr_symbols(),
-                sample.sample_id
-            );
-        }
         let count = observed_bases.hamming(expected_bases, u32::from(max_mismatches));
         u8::try_from(count).expect("Overflow on number of mismatch bases")
     }
@@ -122,13 +107,16 @@ impl BarcodeMatcher {
         let mut next_best_mismatches = 255u8;
         let mut max_mismatches = 255u8;
         let read_bases = encode(read_bases); // NB: this encodes IUPAC bases in the read, but count_mismatches will treat them as no-calls.
+        let expected_len = self.expected_barcode_length();
+        assert!(
+            read_bases.nr_symbols() == expected_len,
+            "Read barcode ({}) length ({}) differs from expected barcode length ({})",
+            decode(&read_bases),
+            read_bases.nr_symbols(),
+            expected_len,
+        );
         for (index, sample_barcode) in self.sample_barcodes.iter().enumerate() {
-            let mismatches = Self::count_mismatches(
-                &read_bases,
-                sample_barcode,
-                &self.samples[index],
-                max_mismatches,
-            );
+            let mismatches = Self::count_mismatches(&read_bases, sample_barcode, max_mismatches);
             if mismatches < best_mismatches {
                 next_best_mismatches = best_mismatches;
                 best_mismatches = mismatches;
@@ -169,20 +157,18 @@ impl BarcodeMatcher {
         }
         let num_no_calls = read_bases.iter().filter(|&&b| byte_is_nocall(b)).count();
         if num_no_calls > (self.max_mismatches as usize) + self.max_ns_in_barcodes {
-            None
-        } else if self.use_cache {
-            if let Some(cached_match) = self.cache.get(read_bases) {
-                Some(*cached_match)
-            } else {
-                let maybe_match = self.assign_internal(read_bases);
-                if let Some(internal_val) = maybe_match {
-                    self.cache.insert(read_bases.to_vec(), internal_val);
-                };
-                maybe_match
-            }
-        } else {
-            self.assign_internal(read_bases)
+            return None;
         }
+        if let Some(cache) = &self.cache {
+            if let Some(cached_match) = cache.get(read_bases) {
+                return Some(*cached_match);
+            }
+        }
+        let maybe_match = self.assign_internal(read_bases);
+        if let (Some(cache), Some(m)) = (self.cache.as_mut(), maybe_match) {
+            cache.insert(read_bases.to_vec(), m);
+        }
+        maybe_match
     }
 }
 
@@ -194,11 +180,7 @@ mod tests {
     /// Given a barcode and integer identifier, generate a sample instance. This helper function
     /// allows creating more succinct testing code.
     fn barcode_to_sample(barcode: &str, idx: usize) -> Sample {
-        Sample {
-            barcode: barcode.to_string(),
-            sample_id: format!("sample_{idx}").to_string(),
-            ordinal: idx,
-        }
+        Sample::new(idx, format!("sample_{idx}"), barcode.to_string())
     }
 
     /// Create a vector of samples from a list of barcodes, for more succinct testing code.
@@ -210,14 +192,11 @@ mod tests {
             .collect::<Vec<_>>()
     }
 
-    /// Helper for running ``BarcodeMatcher::count_mismatches``.  Encodes the bases, and creates a
-    /// dummy sample.
+    /// Helper for running ``BarcodeMatcher::count_mismatches``.  Encodes the bases.
     fn count_mismatches(observed_bases: &str, expected_bases: &str) -> u8 {
-        let sample = barcode_to_sample(expected_bases, 0);
         BarcodeMatcher::count_mismatches(
             &encode(observed_bases.as_bytes()),
             &encode(expected_bases.as_bytes()),
-            &sample,
             255,
         )
     }
@@ -245,16 +224,6 @@ mod tests {
     // ############################################################################################
     // Test BarcodeMatcher::count_mismatches
     // ############################################################################################
-
-    // NB: no need to test for empty barcode in sample (not allowed per 'samples.rs'),
-    // instead test that mismatch counting fails for empty read barcodes
-    #[test]
-    #[should_panic(
-        expected = "Read barcode () length (0) differs from expected barcode (CTATGT) length (6) for sample sample_0"
-    )]
-    fn empty_read_barcode_fails_length_mismatch() {
-        count_mismatches("", "CTATGT");
-    }
 
     #[test]
     fn empty_string_can_run_in_count_mismatches() {
@@ -313,10 +282,12 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "Read barcode (GATTA) length (5) differs from expected barcode (CTATGT) length (6) for sample sample_0"
+        expected = "Read barcode (GATTAGA) length (7) differs from expected barcode length (6)"
     )]
-    fn find_compare_two_sequences_of_different_length() {
-        let _mismatches = count_mismatches("GATTA", "CTATGT");
+    fn assign_panics_when_read_is_longer_than_expected_barcode() {
+        let samples = barcodes_to_samples(&["CTATGT"]);
+        let mut matcher = BarcodeMatcher::new(&samples, 1, 2, false);
+        let _ = matcher.assign(b"GATTAGA");
     }
 
     // ############################################################################################

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub mod barcode_matching;
 pub mod bitenc;
 pub mod samples;
@@ -52,8 +54,7 @@ pub fn encode(bases: &[u8]) -> BitEnc {
         let bit: u8 = if byte_is_nocall(*base) {
             IUPAC_MASKS[b'N' as usize]
         } else {
-            let value = base.to_ascii_uppercase() as usize;
-            if value < 256 { IUPAC_MASKS[value] } else { 0 }
+            IUPAC_MASKS[base.to_ascii_uppercase() as usize]
         };
         vec.push(bit);
     }

--- a/src/lib/samples.rs
+++ b/src/lib/samples.rs
@@ -294,11 +294,9 @@ mod tests {
         let barcode = "GATTACA".to_owned();
         let ordinal = 0;
         let sample = Sample::new(ordinal, name.clone(), barcode.clone());
-        assert_eq!(
-            Sample { sample_id: name, barcode, ordinal },
-            sample,
-            "Sample differed from expectation"
-        );
+        assert_eq!(sample.ordinal, ordinal);
+        assert_eq!(sample.sample_id, name);
+        assert_eq!(sample.barcode, barcode);
     }
 
     // ############################################################################################


### PR DESCRIPTION
This speeds up `fqtk demux` ~9% in my hands and reduces run-to-run variance considerably.

## Changes

* Replace `ahash` with `rustc-hash` for the barcode-match cache (`FxHashMap`); empirically faster than `ahash` and `fxhash` on this workload.
* Lazily allocate the 1M-entry cache only when caching is enabled (`use_cache=true`); previously the cache was always preallocated.
* Increase per-output `BufWriter` capacity from the default 8 KiB to 64 KiB (`OUTPUT_WRITER_BUFFER_SIZE`); profiling showed `write_all_cold` symbol time, indicating short writes spilling out of the default buffer.
* Avoid `format!` on the `usize` read number for the common single-digit case via a `READ_NUMBERS` ASCII-digit table indexed by `read_num`, encapsulated in `ReadSet::write_read_num`.
* Avoid eagerly constructing a `String` for read sample-barcode bases when comparing — only build it on the panic path.
* Make `ReadSet::sample_barcode_sequence` return `Cow<'_, [u8]>` so single-segment barcodes (the common case) avoid a per-record heap allocation.
* Hoist the read-vs-expected length check from per-sample to once-per-`assign_internal` call; `count_mismatches` is now a 3-arg thin wrapper around `BitEnc::hamming`.
* Replace the redundant `use_cache: bool` + always-present cache field with a single `cache: Option<FxHashMap<...>>`.
* Drop the dead `value < 256` bounds check in `encode()` (the `u8` cast can't exceed 255).
* Remove the unused `barcode_bytes` field from `Sample` (it had no production consumer and would silently drift when `BarcodeMatcher::new` uppercased `barcode`).
* Add `#![forbid(unsafe_code)]` at the crate roots.
* Update the rust toolchain to `1.85.0` (from `1.65.0`); apply minor clippy/format adjustments throughout.
* Fix README usage: minimum thread count now correctly stated as 5 (was incorrectly 3).

## Benchmark

### Dataset

5,081,847 paired-end reads (150 bp), simulated by [`holodeck`](https://github.com/fg-labs/holodeck) from GRCh38 chr22 at 30× coverage, paired with synthetic 8B+8B dual-index reads drawn from a 96-sample pool with ~1% unmatched reads.

### Reproduction

```bash
# Inputs
SCRATCH=/tmp/fqtk-bench
mkdir -p "$SCRATCH" && cd "$SCRATCH"

# 1. Reference (any local hg38 works; here chr22 only)
samtools faidx /path/to/Homo_sapiens_assembly38.fasta chr22 > chr22.fa
samtools faidx chr22.fa

# 2. Simulate paired reads (~5M pairs)
holodeck simulate -r chr22.fa -o sim --coverage 30 --read-length 150 \
    --threads 8 --simple-names --compression 1

# 3. Generate I1/I2 + samples.tsv from the R1/R2 pairs
#    (a small helper that picks a random sample per pair, emits 8B+8B index reads)
build_indexes sim.r1.fastq.gz sim.r2.fastq.gz .

# 4. Build & bench
cargo build --release   # on each branch (main, feat/minor-speedups)
cp target/release/fqtk "$SCRATCH/fqtk-<branch>"

for bin in fqtk-main fqtk-pr56; do
    for i in 1 2 3; do
        rm -rf "out-$bin-$i" && mkdir "out-$bin-$i"
        /usr/bin/time -p ./$bin demux \
            --inputs sim.r1.fastq.gz sim.r2.fastq.gz sim.i1.fastq.gz sim.i2.fastq.gz \
            --read-structures +T +T 8B 8B \
            --sample-metadata samples.tsv \
            --output "out-$bin-$i" --threads 8
    done
done
```

### Results

Wall-clock seconds, 8 threads, M3 MacBook Pro, 3 iterations each:

| Binary  | min   | median | max    |
|---------|-------|--------|--------|
| `main`  | 9.25s | 9.95s  | 10.24s |
| PR 56   | 9.15s | 9.15s  | 9.19s  |

Median speedup: **~8.7%**. Run-to-run variance also drops sharply (max−min ≈ 1.0s on `main` vs ≈ 0.04s on this branch).

`demux-metrics.txt` is byte-identical between the two binaries on this dataset.

### Flamegraph

Flamegraph captured via `cargo flamegraph` on the PR build of fqtk against the same dataset (8 threads): https://gist.githubusercontent.com/nh13/29d4aec77bb485181f1595b25858f83c/raw/1cd218f591cf1c73b0000ce90e7c813923616989/flamegraph-pr56.svg
