### PR TITLE
fix: the usage in the readme has triple-backticks

### DIFF
--- a/.github/scripts/update-docs.sh
+++ b/.github/scripts/update-docs.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-echo -e "<!-- start usage -->\n\`\`\`console\n" > usage.txt;
+echo -e "<!-- start usage -->\n\`\`\`\`console\n" > usage.txt;
 ./target/debug/fqtk demux --help | sed -e 's_^[ ]*$__g' >> usage.txt
-echo -e "\`\`\`\n<!-- end usage -->" >> usage.txt;
+echo -e "\`\`\`\`\n<!-- end usage -->" >> usage.txt;
 sed -e '/<!-- start usage -->/,/<!-- end usage -->/!b' -e '/<!-- end usage -->/!d;r usage.txt' -e 'd' README.md > README.md.new;
 mv README.md.new README.md;
 rm usage.txt;

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is highly efficient and multi-threaded for high performance.
 Usage for `fqtk demux` follows:
 
 <!-- start usage -->
-```console
+````console
 
 Performs sample demultiplexing on FASTQs.
 
@@ -181,7 +181,7 @@ Options:
 
   -V, --version
           Print version information
-```
+````
 <!-- end usage -->
 
 ## Installing


### PR DESCRIPTION
Since the command line usage has triple-backticks, we need to add [fenced code blocks](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks) around the usage written to the README