### PR TITLE
fix: bump fgoxide to 0.6.0 and fix `AsRef<Path> usage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "fgoxide"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edd2fe1f0b5f38bb63bf349bdddb840b863502433d9baefcbc54940adc240d8"
+checksum = "fd9c15a55dcaa53f52c94fd11a49fff345ceed255ef353aff1cfc25f32966efc"
 dependencies = [
  "csv",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ bstr = "1.0.1"
 clap = { version = "4.0.25", features = ["derive"] }
 enum_dispatch = "0.3.8"
 env_logger = "0.9.3"
-fgoxide = "0.5.0"
+fgoxide = "0.6.0"
 flate2 = { version = "1.0.25", features = ["zlib-ng"] }  # Force the faster backend that requires a C compiler
 itertools = "0.10.5"
 log = "0.4.17"

--- a/src/lib/samples.rs
+++ b/src/lib/samples.rs
@@ -141,7 +141,7 @@ impl SampleGroup {
     ///   - Will panic if sample metadata sheet is improperly formatted
     ///   - Will panic if a different number of names and barcodes are provided
     ///   - Will panic if each
-    pub fn from_file<P: AsRef<Path>>(path: &P) -> Result<SampleGroup, fgoxide::FgError> {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<SampleGroup, fgoxide::FgError> {
         let reader = DelimFile::default();
         Ok(Self::from_samples(&reader.read(path, DEFAULT_FILE_DELIMETER, false)?))
     }


### PR DESCRIPTION
See: https://github.com/fulcrumgenomics/fgoxide/pull/24