### PR TITLE
doc: update contributing guidelines and add issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report something that isn't working as expected
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To reproduce**
+
+Steps to reproduce the behavior, including the exact `fqtk` command(s) you ran.
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+
+What actually happened, including any relevant error messages or logs.
+
+**Environment**
+
+- OS:
+- Rust version (`rustc --version`):
+- fqtk version (`fqtk --version`):
+
+**Input data**
+
+Sample input files if you can share them, or a description of the input format (read structure, FASTQ layout, etc.).
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contributing guidelines
+    url: https://github.com/fulcrumgenomics/fqtk/blob/main/CONTRIBUTING.md
+    about: Please read the contributing guidelines before opening an issue or pull request.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose new functionality or an enhancement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Use case**
+
+Describe the problem you are trying to solve and why this feature would be valuable. If it is related to a specific workflow, please describe it.
+
+**Proposed solution**
+
+A clear and concise description of what you want to happen, including how you envision the feature working.
+
+**Alternatives considered**
+
+A clear and concise description of any alternative solutions or workarounds you have considered.
+
+**Additional context**
+
+Add any other context, references, or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--
+Thanks for contributing to fqtk! Please fill in the sections below and complete the
+checklist. See CONTRIBUTING.md for the full contribution guidelines.
+-->
+
+## Description
+
+Describe what changes you made and why.
+
+## Related issues
+
+Reference any related issues (e.g., "Closes #123").
+
+## Breaking changes
+
+Note any breaking changes, or "None".
+
+## Checklist
+
+- [ ] The pre-commit checks pass (`./ci/check.sh`), which runs formatting, linting, and tests
+- [ ] Documentation has been updated if needed
+- [ ] Tests have been added for new functionality

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,194 @@
+# Contributing to fqtk
 
-## Updating the README
+Thank you for your interest in contributing to fqtk! This document provides guidelines and information for contributors.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+- [Development Workflow](#development-workflow)
+- [Issue Tracker](#issue-tracker)
+- [Pull Requests](#pull-requests)
+- [Coding Guidelines](#coding-guidelines)
+- [Testing](#testing)
+- [Documentation](#documentation)
+- [Release Process](#release-process)
+- [License](#license)
+
+## Code of Conduct
+
+This project follows the [Fulcrum Genomics Code of Conduct](https://github.com/fulcrumgenomics/.github/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold it. Please be respectful and considerate in all interactions.
+
+## Getting Started
+
+### Prerequisites
+
+- [Rust](https://www.rust-lang.org/tools/install) — the required toolchain version is pinned in [`rust-toolchain.toml`](rust-toolchain.toml) and installed automatically by `rustup` when you build. Using a different toolchain may surface `clippy` lints that are not enforced by CI.
+- Git
+
+### Setting Up Your Development Environment
+
+1. Fork the repository on GitHub
+
+2. Clone your fork:
+   ```console
+   git clone https://github.com/YOUR_USERNAME/fqtk.git
+   cd fqtk
+   ```
+
+3. Add the upstream repository as a remote:
+   ```console
+   git remote add upstream https://github.com/fulcrumgenomics/fqtk.git
+   ```
+
+4. Build the project:
+   ```console
+   cargo build
+   ```
+
+5. Run the tests to ensure everything is working:
+   ```console
+   cargo test
+   ```
+
+## Development Workflow
+
+### Before Making Changes
+
+1. Sync your fork with upstream:
+   ```console
+   git fetch upstream
+   git checkout main
+   git merge upstream/main
+   ```
+
+2. Create a new branch for your changes:
+   ```console
+   git checkout -b feature/your-feature-name
+   ```
+
+### Making Changes
+
+1. Make your changes in your feature branch
+
+2. Ensure your code follows the project's coding standards (see [Coding Guidelines](#coding-guidelines))
+
+3. Write or update tests as needed
+
+4. Run the pre-commit checks before committing:
+   ```console
+   ./ci/check.sh
+   ```
+
+   This script runs:
+   - `cargo fmt` - Code formatting
+   - `cargo clippy` - Linting
+   - `cargo test` - Unit tests
+
+### Committing Changes
+
+- Write clear, concise commit messages
+- Use the imperative mood in commit messages (e.g., "Add feature" not "Added feature")
+- Reference relevant issues in your commit messages when applicable (e.g., "Fix #123")
+
+## Issue Tracker
+
+Bugs and feature requests are tracked on the [GitHub issue tracker](https://github.com/fulcrumgenomics/fqtk/issues). Before opening a new issue, search existing issues to see if it has already been reported.
+
+To open an issue, choose one of the [issue templates](https://github.com/fulcrumgenomics/fqtk/issues/new/choose) and fill in the prompts:
+
+- **Bug report** - for something that isn't working as expected
+- **Feature request** - to propose new functionality
+
+The templates prompt for the details maintainers need (such as reproduction steps, environment, and the motivating use case), so please fill them in as completely as you can.
+
+### Issue Labels
+
+- `bug` - Something isn't working
+- `enhancement` - New feature or request
+- `documentation` - Documentation improvements
+- `good first issue` - Good for newcomers
+
+## Pull Requests
+
+### Submitting a Pull Request
+
+1. Run the full pre-commit checks locally and make sure they pass:
+   ```console
+   ./ci/check.sh
+   ```
+
+2. Push your branch to your fork:
+   ```console
+   git push origin feature/your-feature-name
+   ```
+
+3. Open a pull request against the `main` branch of the upstream repository.
+
+When you open a pull request, the [pull request template](.github/pull_request_template.md) provides a checklist and prompts for the change description, related issues, and any breaking changes. Please complete it before requesting review.
+
+### Review Process
+
+- All PRs require review before merging
+- CI checks must pass (formatting, linting, tests)
+- Address reviewer feedback promptly
+- Keep PRs focused and reasonably sized when possible
+
+## Coding Guidelines
+
+### Style
+
+fqtk follows standard Rust conventions and uses automated tools to ensure consistency:
+
+- **Formatting**: Use `cargo fmt` to format your code
+- **Linting**: Use `cargo clippy` and resolve all warnings
+
+Both are run (along with the tests) by `./ci/check.sh`; run it before pushing. Note that CI enforces a few additional checks not covered by this script — notably that the README usage is up to date (see [Updating the README](#updating-the-readme)).
+
+### Best Practices
+
+- Write idiomatic Rust code
+- Prefer clarity over cleverness
+- Document public APIs with doc comments
+- Handle errors appropriately using `Result` and `anyhow`
+- Avoid `unwrap()` in library code; use proper error handling
+- Keep functions focused and reasonably sized
+
+### Dependencies
+
+- Be conservative when adding new dependencies
+- Prefer well-maintained, widely-used crates
+- Justify new dependencies in your PR description
+
+## Testing
+
+### Running Tests
+
+```console
+# Run all tests
+cargo test
+
+# Run tests with output
+cargo test -- --nocapture
+
+# Run a specific test
+cargo test test_name
+```
+
+### Writing Tests
+
+- Add tests for new functionality
+- Add regression tests for bug fixes
+- Place unit tests in the same file as the code being tested using `#[cfg(test)]` modules
+- Use descriptive test names that explain what is being tested
+
+## Documentation
+
+### Updating the README
 
 The repository README contains a copy of the `fqtk demux` usage, which must be manually kept in sync with the tool.
 
-When updating the tool's arguments or docstring, refresh the README by running the included script: 
+When updating the tool's arguments or docstring, refresh the README by running the included script:
 
 ```console
 bash .github/scripts/update-docs.sh
@@ -11,3 +196,42 @@ bash .github/scripts/update-docs.sh
 
 GitHub Actions will verify that the README remains up-to-date, and commits with outdated usage will fail CI.
 
+### Code Documentation
+
+- Add doc comments (`///`) to public functions, structs, and modules
+- Include examples in doc comments where helpful; these are compiled and run as part of `cargo test`:
+  ```rust
+  /// Returns the sum of two numbers.
+  ///
+  /// # Example
+  /// ```
+  /// assert_eq!(add(2, 3), 5);
+  /// ```
+  pub fn add(a: i32, b: i32) -> i32 {
+      a + b
+  }
+  ```
+- Keep documentation up to date with code changes
+- Preview the rendered documentation locally with `cargo doc --open`
+
+## Release Process
+
+Releases are managed by the maintainers using [`cargo-release`](https://github.com/crate-ci/cargo-release).
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** version for incompatible API changes
+- **MINOR** version for backwards-compatible new functionality
+- **PATCH** version for backwards-compatible bug fixes
+
+See the [README](README.md#releasing-a-new-version) for detailed release instructions.
+
+## License
+
+By contributing to fqtk, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+
+All contributions must be compatible with the MIT license. Do not include code from sources with incompatible licenses.
+
+---
+
+Thank you for contributing to fqtk!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ This project follows the [Fulcrum Genomics Code of Conduct](https://github.com/f
    - `cargo fmt` - Code formatting
    - `cargo clippy` - Linting
    - `cargo test` - Unit tests
+   - README usage check - verifies the embedded `fqtk demux` usage is up to date
 
 ### Committing Changes
 
@@ -143,7 +144,7 @@ fqtk follows standard Rust conventions and uses automated tools to ensure consis
 - **Formatting**: Use `cargo fmt` to format your code
 - **Linting**: Use `cargo clippy` and resolve all warnings
 
-Both are run (along with the tests) by `./ci/check.sh`; run it before pushing. Note that CI enforces a few additional checks not covered by this script — notably that the README usage is up to date (see [Updating the README](#updating-the-readme)).
+These, the tests, and the README usage check (see [Updating the README](#updating-the-readme)) are all run by `./ci/check.sh`, which mirrors the checks CI enforces; run it before pushing.
 
 ### Best Practices
 
@@ -194,7 +195,7 @@ When updating the tool's arguments or docstring, refresh the README by running t
 bash .github/scripts/update-docs.sh
 ```
 
-GitHub Actions will verify that the README remains up-to-date, and commits with outdated usage will fail CI.
+GitHub Actions will verify that the README remains up-to-date, and commits with outdated usage will fail CI. Running `./ci/check.sh` performs this same check locally.
 
 ### Code Documentation
 

--- a/ci/check.sh
+++ b/ci/check.sh
@@ -35,9 +35,21 @@ function run() {
     fi
 }
 
+#####################################################################
+# Regenerates the `fqtk demux` usage embedded in the README and fails
+# if it leaves the working tree dirty (i.e. the README was out of
+# date). Mirrors the README sync check enforced in CI.
+#####################################################################
+function check_docs() {
+    cargo build --locked || return 1
+    bash .github/scripts/update-docs.sh || return 1
+    git diff --exit-code -- README.md
+}
+
 run "Formatting"  "cargo fmt --check --all"
 run "Clippy"      "cargo clippy --locked --all-features --all-targets -- -D warnings"
 run "Unit Tests"  "cargo test --locked"
+run "Docs"        "check_docs"
 
 if [ -z "$failures" ]; then
     banner "Checks Passed"


### PR DESCRIPTION
Based on the rust-by-example contributing doc: https://github.com/rust-lang/rust-by-example

Now includes:

- Code of Conduct - Basic statement about maintaining a welcoming environment
- Getting Started - Prerequisites and step-by-step development environment setup
- Development Workflow - Branch management, making changes, and pre-commit checks
- Issue Tracker - Guidelines for reporting bugs, suggesting features, and common labels
- Pull Requests - Pre-submission checklist, submission process, and review expectations
- Coding Guidelines - Style (rustfmt, clippy), best practices, and dependency policy
- Testing - How to run tests and guidelines for writing new tests
- Documentation - Kept the original README update section and added code documentation guidelines
- Release Process - Summary with reference to the detailed instructions in the README
- License - MIT license contribution agreement