### PR TITLE
feat: Add --template-types option for flexible template output control

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,16 @@ Options:
 
           1. `too-few-bases`: there are too few bases or qualities to extract given the read structures.  For example, if a read is 8bp long but the read structure is `10B`, or if a read is empty and the read structure is `+T`.
 
-      --no-trim
-          Output the original untrimmed reads in the template FASTQ files instead of just the template segments. The read structure is still used for barcode extraction/matching, but template outputs will contain the full original read
+      --template-types <TEMPLATE_TYPES>...
+          The read structure types to include in the template FASTQ output files.
+
+          By default, only template (T) segments are included. To include additional segment types (e.g. to preserve UMIs in the output reads), specify them here. For example, `--template-types M T` will include both molecular barcode and template segments.
+
+          To output the full original reads (all segments), specify all segment types present in your read structure (e.g. `--template-types B M T`).
+
+          Note: If `--template-types` includes any non-`T` type, `T` must be included in `--output-types`.
+
+          [default: T]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ observed base is an N, it will only match expected sample barcrods with an N.  A
 observed base is an R, it will match R, V, D, and N, since the latter IUPAC codes allow both
 A and G (R/V/D/N are a superset of the bases compare to R).
 
-The read structures will be used to extract the observed sample barcode, template bases, 
+The read structures will be used to extract the observed sample barcode, template bases,
 molecular identifiers, and cellular barcodes from each read.  The observed sample barcode will
 be matched to the sample barcodes extracted from the bases in the sample metadata and associated
 read structures.
@@ -174,6 +174,9 @@ Options:
           Skip demultiplexing reads for any of the following reasons, otherwise panic.
 
           1. `too-few-bases`: there are too few bases or qualities to extract given the read structures.  For example, if a read is 8bp long but the read structure is `10B`, or if a read is empty and the read structure is `+T`.
+
+      --no-trim
+          Output the original untrimmed reads in the template FASTQ files instead of just the template segments. The read structure is still used for barcode extraction/matching, but template outputs will contain the full original read
 
   -h, --help
           Print help (see a summary with '-h')

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ A toolkit for working with FASTQ files, written in Rust.
 
 [Visit us at Fulcrum Genomics](https://www.fulcrumgenomics.com) to learn more about how we can power your Bioinformatics with fqtk and beyond.
 
-<a href="mailto:contact@fulcrumgenomics.com?subject=[GitHub inquiry]"><img src="https://img.shields.io/badge/Email_us-%2338b44a.svg?&style=for-the-badge&logo=gmail&logoColor=white"/></a>
-<a href="https://www.fulcrumgenomics.com"><img src="https://img.shields.io/badge/Visit_Us-%2326a8e0.svg?&style=for-the-badge&logo=wordpress&logoColor=white"/></a>
+<a href="mailto:contact@fulcrumgenomics.com?subject=[GitHub inquiry]"><img alt="Email Fulcrum Genomics" src="https://img.shields.io/badge/Email_us-%2338b44a.svg?&style=for-the-badge&logo=gmail&logoColor=white"/></a>
+<a href="https://www.fulcrumgenomics.com"><img alt="Visit Fulcrum Genomics" src="https://img.shields.io/badge/Visit_Us-%2326a8e0.svg?&style=for-the-badge&logo=wordpress&logoColor=white"/></a>
 
 Currently `fqtk` contains a single tool, `demux` for demultiplexing FASTQ files based on sample barcodes.
 `fqtk demux` can be used to demultiplex one or more FASTQ files (e.g. a set of R1, R2 and I1 FASTQ files) with any number of sample barcodes at fixed locations within the reads.
@@ -184,11 +184,13 @@ Options:
       --template-types <TEMPLATE_TYPES>...
           The read structure types to include in the template FASTQ output files.
 
-          By default, only template (T) segments are included. To include additional segment types (e.g. to preserve UMIs in the output reads), specify them here. For example, `--template-types M T` will include both molecular barcode and template segments.
+          By default, only template (T) segments are included. To include additional segment types (e.g. to preserve UMIs in the output read bases), specify them here. For example, `--template-types M T` will concatenate the molecular barcode and template segments.
 
           To output the full original reads (all segments), specify all segment types present in your read structure (e.g. `--template-types B M T`).
 
-          Note: If `--template-types` includes any non-`T` type, `T` must be included in `--output-types`, and each read structure must contain at most one `T` segment.
+          Segments are only merged *within the same physical read*: a non-`T` segment is folded into the template bases only when it is co-located with a `T` in the same read structure (e.g. `8M84T`). A segment on a separate read (e.g. a UMI on its own index read) is never merged into a template on another read; route it via `--output-types` instead, or leave it in the read header. When a UMI (M) is included here it is written into the template bases and is therefore omitted from the read header (it is not written in both places).
+
+          Note: If `--template-types` includes any non-`T` type, `T` must be included in `--output-types`; each requested non-`T` type must be co-located with a `T` in every read structure where it appears; and each read structure must contain at most one `T` segment.
 
           [default: T]
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ Options:
 
           1. `too-few-bases`: there are too few bases or qualities to extract given the read structures.  For example, if a read is 8bp long but the read structure is `10B`, or if a read is empty and the read structure is `+T`.
 
+      --no-trim
+          Output the original untrimmed reads in the template FASTQ files instead of just the template segments. The read structure is still used for barcode extraction/matching, but template outputs will contain the full original read
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/README.md
+++ b/README.md
@@ -181,8 +181,16 @@ Options:
 
           1. `too-few-bases`: there are too few bases or qualities to extract given the read structures.  For example, if a read is 8bp long but the read structure is `10B`, or if a read is empty and the read structure is `+T`.
 
-      --no-trim
-          Output the original untrimmed reads in the template FASTQ files instead of just the template segments. The read structure is still used for barcode extraction/matching, but template outputs will contain the full original read
+      --template-types <TEMPLATE_TYPES>...
+          The read structure types to include in the template FASTQ output files.
+
+          By default, only template (T) segments are included. To include additional segment types (e.g. to preserve UMIs in the output reads), specify them here. For example, `--template-types M T` will include both molecular barcode and template segments.
+
+          To output the full original reads (all segments), specify all segment types present in your read structure (e.g. `--template-types B M T`).
+
+          Note: If `--template-types` includes any non-`T` type, `T` must be included in `--output-types`, and each read structure must contain at most one `T` segment.
+
+          [default: T]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -140,13 +140,22 @@ impl ReadSet {
         first
     }
 
-    /// Reconstructs the original (untrimmed) read for a given source index by concatenating
-    /// all segments from that source in order. Used for --no-trim output.
-    fn original_read_for_source(&self, source_index: usize) -> (Vec<u8>, Vec<u8>) {
+    /// Reconstructs a read for a given source index by concatenating segments of the specified
+    /// types from that source in order. Used for --template-types output.
+    ///
+    /// Note: Segments are concatenated in their original order (as they appear in the read
+    /// structure), preserving the physical arrangement of bases in the original read.
+    fn segments_for_source(
+        &self,
+        source_index: usize,
+        template_types: &HashSet<SegmentType>,
+    ) -> (Vec<u8>, Vec<u8>) {
         let mut seq = Vec::new();
         let mut quals = Vec::new();
         for segment in &self.segments {
-            if segment.source_index == source_index {
+            if segment.source_index == source_index
+                && template_types.contains(&segment.segment_type)
+            {
                 seq.extend_from_slice(&segment.seq);
                 quals.extend_from_slice(&segment.quals);
             }
@@ -414,19 +423,24 @@ impl<W: Write> SampleWriters<W> {
     /// Reads in the read set should be 1:1 with writers in the writer set however this is not
     /// checked at runtime as doing so substantially slows demulitplexing.
     ///
-    /// If `no_trim` is true, template outputs will contain the full original reads instead of
-    /// just the template segments.
-    fn write(&mut self, read_set: &ReadSet, no_trim: bool) -> Result<()> {
-        // Handle template writers separately to support no_trim
+    /// The `template_types` parameter specifies which segment types to include in the template
+    /// output. If it contains only Template, only template segments are written. If it contains
+    /// additional types (e.g. MolecularBarcode), those segments are concatenated with the template.
+    fn write(&mut self, read_set: &ReadSet, template_types: &HashSet<SegmentType>) -> Result<()> {
+        // Handle template writers separately to support template_types
         if let Some(writers) = &mut self.template_writers {
+            // Check if we need to include non-template segments
+            let include_other_segments = template_types.iter().any(|t| *t != SegmentType::Template);
+
             for (read_idx, (writer, segment)) in
                 writers.iter_mut().zip(read_set.template_segments()).enumerate()
             {
                 read_set.write_header(writer, read_idx + 1)?;
                 writer.write_all(b"\n")?;
-                if no_trim {
-                    // Write the original untrimmed read by reconstructing from segments
-                    let (seq, quals) = read_set.original_read_for_source(segment.source_index);
+                if include_other_segments {
+                    // Write segments of the requested types from this source
+                    let (seq, quals) =
+                        read_set.segments_for_source(segment.source_index, template_types);
                     writer.write_all(&seq)?;
                     writer.write_all(b"\n+\n")?;
                     writer.write_all(&quals)?;
@@ -696,11 +710,19 @@ pub(crate) struct Demux {
     #[clap(long, short = 'S')]
     skip_reasons: Vec<SkipReason>,
 
-    /// Output the original untrimmed reads in the template FASTQ files instead of just the
-    /// template segments. The read structure is still used for barcode extraction/matching,
-    /// but template outputs will contain the full original read.
-    #[clap(long)]
-    no_trim: bool,
+    /// The read structure types to include in the template FASTQ output files.
+    ///
+    /// By default, only template (T) segments are included. To include additional segment types
+    /// (e.g. to preserve UMIs in the output reads), specify them here. For example,
+    /// `--template-types M T` will include both molecular barcode and template segments.
+    ///
+    /// To output the full original reads (all segments), specify all segment types present in
+    /// your read structure (e.g. `--template-types B M T`).
+    ///
+    /// Note: If `--template-types` includes any non-`T` type, `T` must be included in
+    /// `--output-types`.
+    #[clap(long, default_value = "T", num_args = 1..)]
+    template_types: Vec<char>,
 }
 
 impl Demux {
@@ -849,13 +871,33 @@ impl Demux {
         Ok((pool, new_sample_writers))
     }
 
+    /// Parses a list of segment type characters into a `HashSet<SegmentType>`, pushing an error
+    /// message to `errors` if any character is invalid.
+    fn parse_segment_types(
+        chars: &[char],
+        error_prefix: &str,
+        errors: &mut Vec<String>,
+    ) -> Result<HashSet<SegmentType>, ReadStructureError> {
+        let result = chars
+            .iter()
+            .map(|&c| SegmentType::try_from(c))
+            .collect::<Result<HashSet<_>, ReadStructureError>>();
+        if let Err(e) = &result {
+            errors.push(format!("{}: {}", error_prefix, e));
+        }
+        result
+    }
+
     /// Checks that inputs to demux are valid and returns open file handles for the inputs.
     /// Checks:
     ///     - That the number of input files and number of read structs provided are the same
     ///     - That the output directory is not read-only
     ///     - That the input files exist
     ///     - That the input files have read permissions.
-    fn validate_and_prepare_inputs(&self) -> Result<(VecOfReaders, HashSet<SegmentType>)> {
+    ///     - That template_types requires T in output_types
+    fn validate_and_prepare_inputs(
+        &self,
+    ) -> Result<(VecOfReaders, HashSet<SegmentType>, HashSet<SegmentType>)> {
         let mut constraint_errors = vec![];
 
         if self.inputs.len() != self.read_structures.len() {
@@ -878,13 +920,50 @@ impl Demux {
                 .push(format!("Ouput directory {:#?} cannot be read-only", self.output));
         }
 
-        let output_segment_types_result = self
-            .output_types
-            .iter()
-            .map(|&c| SegmentType::try_from(c))
-            .collect::<Result<HashSet<_>, ReadStructureError>>();
-        if let Err(e) = &output_segment_types_result {
-            constraint_errors.push(format!("Error parsing segment types to report: {}", e));
+        let output_segment_types_result = Self::parse_segment_types(
+            &self.output_types,
+            "Error parsing segment types to report",
+            &mut constraint_errors,
+        );
+        let template_segment_types_result = Self::parse_segment_types(
+            &self.template_types,
+            "Error parsing template segment types",
+            &mut constraint_errors,
+        );
+
+        // Validate template_types constraints
+        if let (Ok(output_types), Ok(template_types)) =
+            (&output_segment_types_result, &template_segment_types_result)
+        {
+            // template_types must always contain T (the template segment)
+            if !template_types.contains(&SegmentType::Template) {
+                constraint_errors
+                    .push("--template-types must include T (template segment)".to_owned());
+            }
+
+            // If template_types includes non-T segments, output_types must include T
+            // (otherwise there's no template file to write the combined segments to)
+            let has_non_template = template_types.iter().any(|t| *t != SegmentType::Template);
+            if has_non_template && !output_types.contains(&SegmentType::Template) {
+                constraint_errors.push(
+                    "--template-types with non-T segments requires T in --output-types".to_owned(),
+                );
+            }
+
+            // If template_types includes non-T segments, reject read structures with multiple
+            // template segments in a single source, as segments_for_source would produce
+            // duplicated output for each template writer.
+            if has_non_template {
+                for rs in &self.read_structures {
+                    let template_count = rs.segments_by_type(SegmentType::Template).count();
+                    if template_count > 1 {
+                        constraint_errors.push(
+                            "--template-types with non-T segments is not supported when a read structure has multiple template segments".to_owned(),
+                        );
+                        break;
+                    }
+                }
+            }
         }
 
         for input in &self.inputs {
@@ -910,13 +989,14 @@ impl Demux {
 
         if constraint_errors.is_empty() {
             let output_segment_types = output_segment_types_result?;
+            let template_segment_types = template_segment_types_result?;
             if output_segment_types.is_empty() {
                 constraint_errors.push(
                     "No output types requested, must request at least one output segment type."
                         .to_owned(),
                 );
             } else {
-                return Ok((fq_readers_result?, output_segment_types));
+                return Ok((fq_readers_result?, output_segment_types, template_segment_types));
             }
         }
         let mut details = "Inputs failed validation!\n".to_owned();
@@ -931,7 +1011,8 @@ impl Command for Demux {
     #[allow(clippy::too_many_lines)]
     /// Executes the demux command
     fn execute(&self) -> Result<()> {
-        let (fq_readers, output_segment_types) = self.validate_and_prepare_inputs()?;
+        let (fq_readers, output_segment_types, template_segment_types) =
+            self.validate_and_prepare_inputs()?;
 
         let sample_group = SampleGroup::from_file(&self.sample_metadata)?;
         info!(
@@ -1025,10 +1106,11 @@ impl Command for Demux {
             let read_set = ReadSet::combine_readsets(next_read_sets);
             if let Some(barcode_match) = barcode_matcher.assign(&read_set.sample_barcode_sequence())
             {
-                sample_writers[barcode_match.best_match].write(&read_set, self.no_trim)?;
+                sample_writers[barcode_match.best_match]
+                    .write(&read_set, &template_segment_types)?;
                 sample_metrics[barcode_match.best_match].templates += 1;
             } else {
-                sample_writers[unmatched_index].write(&read_set, self.no_trim)?;
+                sample_writers[unmatched_index].write(&read_set, &template_segment_types)?;
                 unmatched_metric.templates += 1;
             }
             logger.record();
@@ -1188,7 +1270,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -1232,7 +1314,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -1272,7 +1354,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         let demux_result = demux_inputs.execute();
         permissions.set_readonly(false);
@@ -1311,7 +1393,7 @@ mod tests {
             threads: 2,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -1347,7 +1429,7 @@ mod tests {
             threads: 2,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -1378,7 +1460,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1397,7 +1479,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_trim_outputs_original_reads() {
+    fn test_template_types_includes_barcode() {
         let tmp = TempDir::new().unwrap();
         let read_structures = vec![ReadStructure::from_str("17B100T").unwrap()];
         let s1_barcode = "AAAAAAAAGATTACAGA";
@@ -1420,7 +1502,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: true,
+            template_types: vec!['B', 'T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1428,7 +1510,7 @@ mod tests {
         let fq_reads = read_fastq(&output_path);
 
         assert_eq!(fq_reads.len(), 1);
-        // With no_trim, the output should be the full original read (barcode + template)
+        // With template_types B T, the output should be the full original read (barcode + template)
         assert_equal(
             &fq_reads[0],
             &OwnedRecord {
@@ -1440,7 +1522,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_trim_with_paired_reads() {
+    fn test_template_types_with_paired_reads() {
         let tmp = TempDir::new().unwrap();
         // R1 has inline barcode, R2 is pure template
         let read_structures = vec![
@@ -1470,7 +1552,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: true,
+            template_types: vec!['B', 'T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1496,6 +1578,227 @@ mod tests {
             &OwnedRecord {
                 head: b"ex_0 2:N:0:AAAAAAAA".to_vec(),
                 seq: r2_full.as_bytes().to_vec(),
+                qual: ";".repeat(100).as_bytes().to_vec(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_template_types_with_umi() {
+        let tmp = TempDir::new().unwrap();
+        // Read structure with barcode, UMI, and template
+        let read_structures = vec![ReadStructure::from_str("8B8M84T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let umi = "GGGGGGGG";
+        let template = "T".repeat(84);
+        let full_read = s1_barcode.to_owned() + umi + &template;
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &[&full_read])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // Include only M and T (UMI + template), exclude barcode
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['M', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+
+        let output_path = output_dir.join("Sample0000.R1.fq.gz");
+        let fq_reads = read_fastq(&output_path);
+
+        assert_eq!(fq_reads.len(), 1);
+        // With template_types M T, the output should be UMI + template (no barcode)
+        let expected_seq = umi.to_owned() + &template;
+        assert_equal(
+            &fq_reads[0],
+            &OwnedRecord {
+                head: b"ex_0:GGGGGGGG 1:N:0:AAAAAAAA".to_vec(),
+                seq: expected_seq.as_bytes().to_vec(),
+                qual: ";".repeat(92).as_bytes().to_vec(),
+            },
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "--template-types with non-T segments requires T in --output-types")]
+    fn test_template_types_requires_template_in_output_types() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("8B92T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &["A".repeat(100).as_str()])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // This should fail: output_types has only B, but template_types has B T
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['B'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['B', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "--template-types must include T (template segment)")]
+    fn test_template_types_must_include_template() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("8B8M84T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &["A".repeat(100).as_str()])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // This should fail: template_types doesn't include T
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['B', 'M'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Error parsing template segment types")]
+    fn test_template_types_invalid_segment_type() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("8B92T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &["A".repeat(100).as_str()])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // This should fail: 'X' is not a valid segment type
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['X', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "--template-types with non-T segments is not supported when a read structure has multiple template segments"
+    )]
+    fn test_template_types_non_t_rejects_multi_template_read_structure() {
+        let tmp = TempDir::new().unwrap();
+        // Read structure with multiple T segments in one source
+        let read_structures = vec![ReadStructure::from_str("8B20T20S20T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(
+            &tmp,
+            "ex",
+            "ex",
+            &[&(s1_barcode.to_owned()
+                + &"A".repeat(20)
+                + &"C".repeat(20)
+                + &"T".repeat(20))],
+        )];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // This should fail: template_types includes B (non-T) and read structure has multiple T segments
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['B', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
+    fn test_template_types_all_segments_with_skip() {
+        let tmp = TempDir::new().unwrap();
+        // Read structure with barcode, skip, UMI, and template
+        let read_structures = vec![ReadStructure::from_str("8B4S8M80T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let skip = "NNNN";
+        let umi = "GGGGGGGG";
+        let template = "T".repeat(80);
+        let full_read = s1_barcode.to_owned() + skip + umi + &template;
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &[&full_read])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // Include all segment types including skip
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['B', 'S', 'M', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+
+        let output_path = output_dir.join("Sample0000.R1.fq.gz");
+        let fq_reads = read_fastq(&output_path);
+
+        assert_eq!(fq_reads.len(), 1);
+        // With all template_types, the output should be the full original read
+        assert_equal(
+            &fq_reads[0],
+            &OwnedRecord {
+                head: b"ex_0:GGGGGGGG 1:N:0:AAAAAAAA".to_vec(),
+                seq: full_read.as_bytes().to_vec(),
                 qual: ";".repeat(100).as_bytes().to_vec(),
             },
         );
@@ -1533,7 +1836,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1610,7 +1913,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1667,7 +1970,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1741,7 +2044,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1814,7 +2117,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1880,7 +2183,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux.execute().unwrap();
 
@@ -1945,7 +2248,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux.execute().unwrap();
 
@@ -2010,7 +2313,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -2085,7 +2388,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -2120,7 +2423,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -2155,7 +2458,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -2195,7 +2498,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -2232,7 +2535,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![SkipReason::TooFewBases],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -46,6 +46,8 @@ struct FastqSegment {
     quals: Vec<u8>,
     /// the type of segment being stored
     segment_type: SegmentType,
+    /// the index of the source FASTQ file this segment came from
+    source_index: usize,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -136,6 +138,20 @@ impl ReadSet {
         }
 
         first
+    }
+
+    /// Reconstructs the original (untrimmed) read for a given source index by concatenating
+    /// all segments from that source in order. Used for --no-trim output.
+    fn original_read_for_source(&self, source_index: usize) -> (Vec<u8>, Vec<u8>) {
+        let mut seq = Vec::new();
+        let mut quals = Vec::new();
+        for segment in &self.segments {
+            if segment.source_index == source_index {
+                seq.extend_from_slice(&segment.seq);
+                quals.extend_from_slice(&segment.quals);
+            }
+        }
+        (seq, quals)
     }
 
     /// Writes the FASTQ header to the given writer.  Substitutes in the given read number into
@@ -280,6 +296,8 @@ struct ReadSetIterator {
     source: FastqReader<Box<dyn BufRead + Send>>,
     /// Valid reasons for skipping reads, otherwise panic!
     skip_reasons: Vec<SkipReason>,
+    /// The index of this FASTQ source (0-based), used for tracking original reads.
+    source_index: usize,
 }
 
 impl Iterator for ReadSetIterator {
@@ -333,6 +351,7 @@ impl Iterator for ReadSetIterator {
                     seq: seq.to_vec(),
                     quals: quals.to_vec(),
                     segment_type: read_segment.kind,
+                    source_index: self.source_index,
                 });
             }
             Some(ReadSet { header: read_name.to_vec(), segments, skip_reason: None })
@@ -344,13 +363,14 @@ impl Iterator for ReadSetIterator {
 
 impl ReadSetIterator {
     /// Instantiates a new iterator over the read sets for a set of FASTQs with defined read
-    /// structures
+    /// structures.
     pub fn new(
         read_structure: ReadStructure,
         source: FastqReader<Box<dyn BufRead + Send>>,
         skip_reasons: Vec<SkipReason>,
+        source_index: usize,
     ) -> Self {
-        Self { read_structure, source, skip_reasons }
+        Self { read_structure, source, skip_reasons, source_index }
     }
 }
 
@@ -377,7 +397,9 @@ impl<W: Write> SampleWriters<W> {
     /// Destroys this struct and decomposes it into its component types. Used when swapping
     /// writers for pooled writers.
     #[allow(clippy::type_complexity)]
-    fn into_parts(self) -> (String, Option<Vec<W>>, Option<Vec<W>>, Option<Vec<W>>, Option<Vec<W>>) {
+    fn into_parts(
+        self,
+    ) -> (String, Option<Vec<W>>, Option<Vec<W>>, Option<Vec<W>>, Option<Vec<W>>) {
         (
             self.name,
             self.template_writers,
@@ -391,9 +413,35 @@ impl<W: Write> SampleWriters<W> {
     /// ``Self`` struct.
     /// Reads in the read set should be 1:1 with writers in the writer set however this is not
     /// checked at runtime as doing so substantially slows demulitplexing.
-    fn write(&mut self, read_set: &ReadSet) -> Result<()> {
+    ///
+    /// If `no_trim` is true, template outputs will contain the full original reads instead of
+    /// just the template segments.
+    fn write(&mut self, read_set: &ReadSet, no_trim: bool) -> Result<()> {
+        // Handle template writers separately to support no_trim
+        if let Some(writers) = &mut self.template_writers {
+            for (read_idx, (writer, segment)) in
+                writers.iter_mut().zip(read_set.template_segments()).enumerate()
+            {
+                read_set.write_header(writer, read_idx + 1)?;
+                writer.write_all(b"\n")?;
+                if no_trim {
+                    // Write the original untrimmed read by reconstructing from segments
+                    let (seq, quals) = read_set.original_read_for_source(segment.source_index);
+                    writer.write_all(&seq)?;
+                    writer.write_all(b"\n+\n")?;
+                    writer.write_all(&quals)?;
+                } else {
+                    // Write just the template segment
+                    writer.write_all(segment.seq.as_slice())?;
+                    writer.write_all(b"\n+\n")?;
+                    writer.write_all(segment.quals.as_slice())?;
+                }
+                writer.write_all(b"\n")?;
+            }
+        }
+
+        // Handle other segment types (barcodes, UMIs, etc.) - always write segments, not originals
         for (writers_opt, segments) in [
-            (&mut self.template_writers, &mut read_set.template_segments()),
             (&mut self.sample_barcode_writers, &mut read_set.sample_barcode_segments()),
             (&mut self.molecular_barcode_writers, &mut read_set.molecular_barcode_segments()),
             (&mut self.cellular_barcode_writers, &mut read_set.cellular_barcode_segments()),
@@ -419,10 +467,14 @@ impl SampleWriters<PooledWriter> {
     /// # Errors
     ///     - Will error if closing of the ``PooledWriter``s fails for any reason
     fn close(self) -> Result<()> {
-        for writers in
-            [self.template_writers, self.sample_barcode_writers, self.molecular_barcode_writers, self.cellular_barcode_writers]
-                .into_iter()
-                .flatten()
+        for writers in [
+            self.template_writers,
+            self.sample_barcode_writers,
+            self.molecular_barcode_writers,
+            self.cellular_barcode_writers,
+        ]
+        .into_iter()
+        .flatten()
         {
             writers.into_iter().try_for_each(PooledWriter::close)?;
         }
@@ -541,7 +593,7 @@ impl DemuxMetric {
 /// observed base is an R, it will match R, V, D, and N, since the latter IUPAC codes allow both
 /// A and G (R/V/D/N are a superset of the bases compare to R).
 ///
-/// The read structures will be used to extract the observed sample barcode, template bases, 
+/// The read structures will be used to extract the observed sample barcode, template bases,
 /// molecular identifiers, and cellular barcodes from each read.  The observed sample barcode will
 /// be matched to the sample barcodes extracted from the bases in the sample metadata and associated
 /// read structures.
@@ -643,6 +695,12 @@ pub(crate) struct Demux {
     ///    if a read is empty and the read structure is `+T`.
     #[clap(long, short = 'S')]
     skip_reasons: Vec<SkipReason>,
+
+    /// Output the original untrimmed reads in the template FASTQ files instead of just the
+    /// template segments. The read structure is still used for barcode extraction/matching,
+    /// but template outputs will contain the full original read.
+    #[clap(long)]
+    no_trim: bool,
 }
 
 impl Demux {
@@ -758,7 +816,8 @@ impl Demux {
             .compression_level(u8::try_from(compression_level)?)?;
 
         for sample in sample_writers {
-            let (name, template_writers, barcode_writers, mol_writers, cb_writers) = sample.into_parts();
+            let (name, template_writers, barcode_writers, mol_writers, cb_writers) =
+                sample.into_parts();
             let mut new_template_writers = None;
             let mut new_sample_barcode_writers = None;
             let mut new_molecular_barcode_writers = None;
@@ -920,9 +979,15 @@ impl Command for Demux {
 
         let mut fq_iterators = fq_sources
             .zip(self.read_structures.clone())
-            .map(|(source, read_structure)| {
-                ReadSetIterator::new(read_structure, source, self.skip_reasons.clone())
-                    .read_ahead(1000, 1000)
+            .enumerate()
+            .map(|(source_index, (source, read_structure))| {
+                ReadSetIterator::new(
+                    read_structure,
+                    source,
+                    self.skip_reasons.clone(),
+                    source_index,
+                )
+                .read_ahead(1000, 1000)
             })
             .collect::<Vec<_>>();
 
@@ -960,10 +1025,10 @@ impl Command for Demux {
             let read_set = ReadSet::combine_readsets(next_read_sets);
             if let Some(barcode_match) = barcode_matcher.assign(&read_set.sample_barcode_sequence())
             {
-                sample_writers[barcode_match.best_match].write(&read_set)?;
+                sample_writers[barcode_match.best_match].write(&read_set, self.no_trim)?;
                 sample_metrics[barcode_match.best_match].templates += 1;
             } else {
-                sample_writers[unmatched_index].write(&read_set)?;
+                sample_writers[unmatched_index].write(&read_set, self.no_trim)?;
                 unmatched_metric.templates += 1;
             }
             logger.record();
@@ -1123,6 +1188,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1166,6 +1232,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1205,6 +1272,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         let demux_result = demux_inputs.execute();
         permissions.set_readonly(false);
@@ -1243,6 +1311,7 @@ mod tests {
             threads: 2,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1278,6 +1347,7 @@ mod tests {
             threads: 2,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1308,6 +1378,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1320,6 +1391,111 @@ mod tests {
             &OwnedRecord {
                 head: b"ex_0 1:N:0:AAAAAAAAGATTACAGA".to_vec(),
                 seq: "A".repeat(100).as_bytes().to_vec(),
+                qual: ";".repeat(100).as_bytes().to_vec(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_no_trim_outputs_original_reads() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("17B100T").unwrap()];
+        let s1_barcode = "AAAAAAAAGATTACAGA";
+        let template_seq = "T".repeat(100);
+        let full_read = s1_barcode.to_owned() + &template_seq;
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &[&full_read])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            no_trim: true,
+        };
+        demux_inputs.execute().unwrap();
+
+        let output_path = output_dir.join("Sample0000.R1.fq.gz");
+        let fq_reads = read_fastq(&output_path);
+
+        assert_eq!(fq_reads.len(), 1);
+        // With no_trim, the output should be the full original read (barcode + template)
+        assert_equal(
+            &fq_reads[0],
+            &OwnedRecord {
+                head: b"ex_0 1:N:0:AAAAAAAAGATTACAGA".to_vec(),
+                seq: full_read.as_bytes().to_vec(),
+                qual: ";".repeat(117).as_bytes().to_vec(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_no_trim_with_paired_reads() {
+        let tmp = TempDir::new().unwrap();
+        // R1 has inline barcode, R2 is pure template
+        let read_structures = vec![
+            ReadStructure::from_str("8B92T").unwrap(),
+            ReadStructure::from_str("100T").unwrap(),
+        ];
+        let s1_barcode = "AAAAAAAA";
+        let r1_full = s1_barcode.to_owned() + &"A".repeat(92);
+        let r2_full = "T".repeat(100);
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![
+            fastq_file(&tmp, "ex_R1", "ex", &[&r1_full]),
+            fastq_file(&tmp, "ex_R2", "ex", &[&r2_full]),
+        ];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            no_trim: true,
+        };
+        demux_inputs.execute().unwrap();
+
+        // R1 output should be full 100bp read (barcode + template)
+        let r1_path = output_dir.join("Sample0000.R1.fq.gz");
+        let r1_reads = read_fastq(&r1_path);
+        assert_eq!(r1_reads.len(), 1);
+        assert_equal(
+            &r1_reads[0],
+            &OwnedRecord {
+                head: b"ex_0 1:N:0:AAAAAAAA".to_vec(),
+                seq: r1_full.as_bytes().to_vec(),
+                qual: ";".repeat(100).as_bytes().to_vec(),
+            },
+        );
+
+        // R2 output should be full 100bp read (same as template since no barcode)
+        let r2_path = output_dir.join("Sample0000.R2.fq.gz");
+        let r2_reads = read_fastq(&r2_path);
+        assert_eq!(r2_reads.len(), 1);
+        assert_equal(
+            &r2_reads[0],
+            &OwnedRecord {
+                head: b"ex_0 2:N:0:AAAAAAAA".to_vec(),
+                seq: r2_full.as_bytes().to_vec(),
                 qual: ";".repeat(100).as_bytes().to_vec(),
             },
         );
@@ -1357,6 +1533,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1433,6 +1610,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1489,6 +1667,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1562,6 +1741,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1634,6 +1814,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1699,6 +1880,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux.execute().unwrap();
 
@@ -1763,6 +1945,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux.execute().unwrap();
 
@@ -1827,6 +2010,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1901,6 +2085,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1935,6 +2120,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1969,6 +2155,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -2008,6 +2195,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -2044,6 +2232,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![SkipReason::TooFewBases],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -2071,7 +2260,7 @@ mod tests {
 
     fn seg(bases: &[u8], segment_type: SegmentType) -> FastqSegment {
         let quals = vec![b'#'; bases.len()];
-        FastqSegment { seq: bases.to_vec(), quals, segment_type }
+        FastqSegment { seq: bases.to_vec(), quals, segment_type, source_index: 0 }
     }
 
     #[test]
@@ -2218,9 +2407,7 @@ mod tests {
 
         let read_set = read_set(segments);
 
-        let expected = vec![
-            seg("ACGTACGT".as_bytes(), SegmentType::CellularBarcode),
-        ];
+        let expected = vec![seg("ACGTACGT".as_bytes(), SegmentType::CellularBarcode)];
 
         assert_eq!(expected, read_set.cellular_barcode_segments().cloned().collect::<Vec<_>>());
     }

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -11,7 +11,6 @@ use log::info;
 use pooled_writer::{Pool, PoolBuilder, PooledWriter, bgzf::BgzfCompressor};
 use proglog::{CountFormatterKind, ProgLogBuilder};
 use read_structure::ReadStructure;
-use read_structure::ReadStructureError;
 use read_structure::SegmentType;
 use seq_io::fastq::Reader as FastqReader;
 use seq_io::fastq::Record;
@@ -140,13 +139,22 @@ impl ReadSet {
         first
     }
 
-    /// Reconstructs the original (untrimmed) read for a given source index by concatenating
-    /// all segments from that source in order. Used for --no-trim output.
-    fn original_read_for_source(&self, source_index: usize) -> (Vec<u8>, Vec<u8>) {
+    /// Reconstructs a read for a given source index by concatenating segments of the specified
+    /// types from that source in order. Used for --template-types output.
+    ///
+    /// Note: Segments are concatenated in their original order (as they appear in the read
+    /// structure), preserving the physical arrangement of bases in the original read.
+    fn segments_for_source(
+        &self,
+        source_index: usize,
+        template_types: &HashSet<SegmentType>,
+    ) -> (Vec<u8>, Vec<u8>) {
         let mut seq = Vec::new();
         let mut quals = Vec::new();
         for segment in &self.segments {
-            if segment.source_index == source_index {
+            if segment.source_index == source_index
+                && template_types.contains(&segment.segment_type)
+            {
                 seq.extend_from_slice(&segment.seq);
                 quals.extend_from_slice(&segment.quals);
             }
@@ -414,19 +422,24 @@ impl<W: Write> SampleWriters<W> {
     /// Reads in the read set should be 1:1 with writers in the writer set however this is not
     /// checked at runtime as doing so substantially slows demulitplexing.
     ///
-    /// If `no_trim` is true, template outputs will contain the full original reads instead of
-    /// just the template segments.
-    fn write(&mut self, read_set: &ReadSet, no_trim: bool) -> Result<()> {
-        // Handle template writers separately to support no_trim
+    /// The `template_types` parameter specifies which segment types to include in the template
+    /// output. If it contains only Template, only template segments are written. If it contains
+    /// additional types (e.g. MolecularBarcode), those segments are concatenated with the template.
+    fn write(&mut self, read_set: &ReadSet, template_types: &HashSet<SegmentType>) -> Result<()> {
+        // Handle template writers separately to support template_types
         if let Some(writers) = &mut self.template_writers {
+            // Check if we need to include non-template segments
+            let include_other_segments = template_types.iter().any(|t| *t != SegmentType::Template);
+
             for (read_idx, (writer, segment)) in
                 writers.iter_mut().zip(read_set.template_segments()).enumerate()
             {
                 read_set.write_header(writer, read_idx + 1)?;
                 writer.write_all(b"\n")?;
-                if no_trim {
-                    // Write the original untrimmed read by reconstructing from segments
-                    let (seq, quals) = read_set.original_read_for_source(segment.source_index);
+                if include_other_segments {
+                    // Write segments of the requested types from this source
+                    let (seq, quals) =
+                        read_set.segments_for_source(segment.source_index, template_types);
                     writer.write_all(&seq)?;
                     writer.write_all(b"\n+\n")?;
                     writer.write_all(&quals)?;
@@ -696,11 +709,19 @@ pub(crate) struct Demux {
     #[clap(long, short = 'S')]
     skip_reasons: Vec<SkipReason>,
 
-    /// Output the original untrimmed reads in the template FASTQ files instead of just the
-    /// template segments. The read structure is still used for barcode extraction/matching,
-    /// but template outputs will contain the full original read.
-    #[clap(long)]
-    no_trim: bool,
+    /// The read structure types to include in the template FASTQ output files.
+    ///
+    /// By default, only template (T) segments are included. To include additional segment types
+    /// (e.g. to preserve UMIs in the output reads), specify them here. For example,
+    /// `--template-types M T` will include both molecular barcode and template segments.
+    ///
+    /// To output the full original reads (all segments), specify all segment types present in
+    /// your read structure (e.g. `--template-types B M T`).
+    ///
+    /// Note: If `--template-types` includes any non-`T` type, `T` must be included in
+    /// `--output-types`, and each read structure must contain at most one `T` segment.
+    #[clap(long, default_value = "T", num_args = 1..)]
+    template_types: Vec<char>,
 }
 
 impl Demux {
@@ -849,13 +870,36 @@ impl Demux {
         Ok((pool, new_sample_writers))
     }
 
+    /// Parses a list of segment type characters into a `HashSet<SegmentType>`, returning
+    /// `Some(set)` on success or `None` after pushing an error message to `errors` if any
+    /// character is invalid.
+    fn parse_segment_types(
+        chars: &[char],
+        error_prefix: &str,
+        errors: &mut Vec<String>,
+    ) -> Option<HashSet<SegmentType>> {
+        match chars.iter().map(|&c| SegmentType::try_from(c)).collect::<Result<HashSet<_>, _>>() {
+            Ok(set) => Some(set),
+            Err(e) => {
+                errors.push(format!("{}: {}", error_prefix, e));
+                None
+            }
+        }
+    }
+
     /// Checks that inputs to demux are valid and returns open file handles for the inputs.
     /// Checks:
     ///     - That the number of input files and number of read structs provided are the same
     ///     - That the output directory is not read-only
     ///     - That the input files exist
     ///     - That the input files have read permissions.
-    fn validate_and_prepare_inputs(&self) -> Result<(VecOfReaders, HashSet<SegmentType>)> {
+    ///     - That `--output-types` and `--template-types` parse to valid segment types
+    ///     - That `--template-types` includes T (the template segment)
+    ///     - That `--output-types` includes T when `--template-types` has non-T segments
+    ///     - That no read structure has multiple T segments when `--template-types` has non-T
+    fn validate_and_prepare_inputs(
+        &self,
+    ) -> Result<(VecOfReaders, HashSet<SegmentType>, HashSet<SegmentType>)> {
         let mut constraint_errors = vec![];
 
         if self.inputs.len() != self.read_structures.len() {
@@ -878,13 +922,65 @@ impl Demux {
                 .push(format!("Ouput directory {:#?} cannot be read-only", self.output));
         }
 
-        let output_segment_types_result = self
-            .output_types
-            .iter()
-            .map(|&c| SegmentType::try_from(c))
-            .collect::<Result<HashSet<_>, ReadStructureError>>();
-        if let Err(e) = &output_segment_types_result {
-            constraint_errors.push(format!("Error parsing segment types to report: {}", e));
+        let output_segment_types_result = Self::parse_segment_types(
+            &self.output_types,
+            "Error parsing segment types to report",
+            &mut constraint_errors,
+        );
+        let template_segment_types_result = Self::parse_segment_types(
+            &self.template_types,
+            "Error parsing template segment types",
+            &mut constraint_errors,
+        );
+
+        // Validate template_types constraints
+        if let (Some(output_types), Some(template_types)) =
+            (&output_segment_types_result, &template_segment_types_result)
+        {
+            // template_types must always contain T (the template segment)
+            if !template_types.contains(&SegmentType::Template) {
+                constraint_errors
+                    .push("--template-types must include T (template segment)".to_owned());
+            }
+
+            // If template_types includes non-T segments, output_types must include T
+            // (otherwise there's no template file to write the combined segments to)
+            let has_non_template = template_types.iter().any(|t| *t != SegmentType::Template);
+            if has_non_template && !output_types.contains(&SegmentType::Template) {
+                constraint_errors.push(
+                    "--template-types with non-T segments requires T in --output-types".to_owned(),
+                );
+            }
+
+            // If template_types includes non-T segments, reject read structures with multiple
+            // template segments in a single source, as segments_for_source would produce
+            // duplicated output for each template writer.
+            if has_non_template {
+                for (idx, rs) in self.read_structures.iter().enumerate() {
+                    let template_count = rs.segments_by_type(SegmentType::Template).count();
+                    if template_count > 1 {
+                        constraint_errors.push(format!(
+                            "--template-types with non-T segments is not supported when a read structure has multiple template segments (read structure #{} has {})",
+                            idx + 1, template_count
+                        ));
+                    }
+                }
+
+                // Each requested non-T type must appear in at least one read structure, else the
+                // request is silently a no-op (segments_for_source emits only the template).
+                for segment_type in template_types.iter().filter(|t| **t != SegmentType::Template) {
+                    let present = self
+                        .read_structures
+                        .iter()
+                        .any(|rs| rs.segments_by_type(*segment_type).count() > 0);
+                    if !present {
+                        constraint_errors.push(format!(
+                            "--template-types includes {} but no read structure contains that segment type",
+                            segment_type.value()
+                        ));
+                    }
+                }
+            }
         }
 
         for input in &self.inputs {
@@ -909,14 +1005,19 @@ impl Demux {
         }
 
         if constraint_errors.is_empty() {
-            let output_segment_types = output_segment_types_result?;
+            // Safe: parse_segment_types only returns None after pushing to constraint_errors,
+            // so if constraint_errors is empty both must be Some.
+            let output_segment_types =
+                output_segment_types_result.expect("output segment types parsed without errors");
+            let template_segment_types = template_segment_types_result
+                .expect("template segment types parsed without errors");
             if output_segment_types.is_empty() {
                 constraint_errors.push(
                     "No output types requested, must request at least one output segment type."
                         .to_owned(),
                 );
             } else {
-                return Ok((fq_readers_result?, output_segment_types));
+                return Ok((fq_readers_result?, output_segment_types, template_segment_types));
             }
         }
         let mut details = "Inputs failed validation!\n".to_owned();
@@ -931,7 +1032,8 @@ impl Command for Demux {
     #[allow(clippy::too_many_lines)]
     /// Executes the demux command
     fn execute(&self) -> Result<()> {
-        let (fq_readers, output_segment_types) = self.validate_and_prepare_inputs()?;
+        let (fq_readers, output_segment_types, template_segment_types) =
+            self.validate_and_prepare_inputs()?;
 
         let sample_group = SampleGroup::from_file(&self.sample_metadata)?;
         info!(
@@ -1025,10 +1127,11 @@ impl Command for Demux {
             let read_set = ReadSet::combine_readsets(next_read_sets);
             if let Some(barcode_match) = barcode_matcher.assign(&read_set.sample_barcode_sequence())
             {
-                sample_writers[barcode_match.best_match].write(&read_set, self.no_trim)?;
+                sample_writers[barcode_match.best_match]
+                    .write(&read_set, &template_segment_types)?;
                 sample_metrics[barcode_match.best_match].templates += 1;
             } else {
-                sample_writers[unmatched_index].write(&read_set, self.no_trim)?;
+                sample_writers[unmatched_index].write(&read_set, &template_segment_types)?;
                 unmatched_metric.templates += 1;
             }
             logger.record();
@@ -1188,7 +1291,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -1232,7 +1335,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -1272,7 +1375,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         let demux_result = demux_inputs.execute();
         permissions.set_readonly(false);
@@ -1311,7 +1414,7 @@ mod tests {
             threads: 2,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -1347,7 +1450,7 @@ mod tests {
             threads: 2,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -1378,7 +1481,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1397,7 +1500,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_trim_outputs_original_reads() {
+    fn test_template_types_includes_barcode() {
         let tmp = TempDir::new().unwrap();
         let read_structures = vec![ReadStructure::from_str("17B100T").unwrap()];
         let s1_barcode = "AAAAAAAAGATTACAGA";
@@ -1420,7 +1523,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: true,
+            template_types: vec!['B', 'T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1428,7 +1531,7 @@ mod tests {
         let fq_reads = read_fastq(&output_path);
 
         assert_eq!(fq_reads.len(), 1);
-        // With no_trim, the output should be the full original read (barcode + template)
+        // With template_types B T, the output should be the full original read (barcode + template)
         assert_equal(
             &fq_reads[0],
             &OwnedRecord {
@@ -1440,7 +1543,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_trim_with_paired_reads() {
+    fn test_template_types_with_paired_reads() {
         let tmp = TempDir::new().unwrap();
         // R1 has inline barcode, R2 is pure template
         let read_structures = vec![
@@ -1470,7 +1573,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: true,
+            template_types: vec!['B', 'T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1497,6 +1600,306 @@ mod tests {
                 head: b"ex_0 2:N:0:AAAAAAAA".to_vec(),
                 seq: r2_full.as_bytes().to_vec(),
                 qual: ";".repeat(100).as_bytes().to_vec(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_template_types_with_umi() {
+        let tmp = TempDir::new().unwrap();
+        // Read structure with barcode, UMI, and template
+        let read_structures = vec![ReadStructure::from_str("8B8M84T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let umi = "GGGGGGGG";
+        let template = "T".repeat(84);
+        let full_read = s1_barcode.to_owned() + umi + &template;
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &[&full_read])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // Include only M and T (UMI + template), exclude barcode
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['M', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+
+        let output_path = output_dir.join("Sample0000.R1.fq.gz");
+        let fq_reads = read_fastq(&output_path);
+
+        assert_eq!(fq_reads.len(), 1);
+        // With template_types M T, the output should be UMI + template (no barcode)
+        let expected_seq = umi.to_owned() + &template;
+        assert_equal(
+            &fq_reads[0],
+            &OwnedRecord {
+                head: b"ex_0:GGGGGGGG 1:N:0:AAAAAAAA".to_vec(),
+                seq: expected_seq.as_bytes().to_vec(),
+                qual: ";".repeat(92).as_bytes().to_vec(),
+            },
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "--template-types with non-T segments requires T in --output-types")]
+    fn test_template_types_requires_template_in_output_types() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("8B92T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &["A".repeat(100).as_str()])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // This should fail: output_types has only B, but template_types has B T
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['B'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['B', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "--template-types must include T (template segment)")]
+    fn test_template_types_must_include_template() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("8B8M84T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &["A".repeat(100).as_str()])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // This should fail: template_types doesn't include T
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['B', 'M'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "--template-types includes C but no read structure contains that segment type"
+    )]
+    fn test_template_types_absent_type_rejected() {
+        let tmp = TempDir::new().unwrap();
+        // Read structure has B and T but no C (cellular barcode).
+        let read_structures = vec![ReadStructure::from_str("8B92T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &["A".repeat(100).as_str()])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // This should fail: C is requested but absent from every read structure.
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['C', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Error parsing template segment types")]
+    fn test_template_types_invalid_segment_type() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("8B92T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &["A".repeat(100).as_str()])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // This should fail: 'X' is not a valid segment type
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['X', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "--template-types with non-T segments is not supported when a read structure has multiple template segments (read structure #1 has 2)"
+    )]
+    fn test_template_types_non_t_rejects_multi_template_read_structure() {
+        let tmp = TempDir::new().unwrap();
+        // Read structure with multiple T segments in one source
+        let read_structures = vec![ReadStructure::from_str("8B20T20S20T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(
+            &tmp,
+            "ex",
+            "ex",
+            &[&(s1_barcode.to_owned() + &"A".repeat(20) + &"C".repeat(20) + &"T".repeat(20))],
+        )];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // This should fail: template_types includes B (non-T) and read structure has multiple T segments
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['B', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
+    fn test_template_types_all_segments_with_skip() {
+        let tmp = TempDir::new().unwrap();
+        // Read structure with barcode, skip, UMI, and template
+        let read_structures = vec![ReadStructure::from_str("8B4S8M80T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let skip = "NNNN";
+        let umi = "GGGGGGGG";
+        let template = "T".repeat(80);
+        let full_read = s1_barcode.to_owned() + skip + umi + &template;
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &[&full_read])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // Include all segment types including skip
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['B', 'S', 'M', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+
+        let output_path = output_dir.join("Sample0000.R1.fq.gz");
+        let fq_reads = read_fastq(&output_path);
+
+        assert_eq!(fq_reads.len(), 1);
+        // With all template_types, the output should be the full original read
+        assert_equal(
+            &fq_reads[0],
+            &OwnedRecord {
+                head: b"ex_0:GGGGGGGG 1:N:0:AAAAAAAA".to_vec(),
+                seq: full_read.as_bytes().to_vec(),
+                qual: ";".repeat(100).as_bytes().to_vec(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_template_types_with_cellular_barcode() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("10M8B7C75T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let s1_umi = "ATCGATCGAT";
+        let s1_cellular_barcode = "GATTACA";
+        let template = "T".repeat(75);
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(
+            &tmp,
+            "ex",
+            "ex",
+            &[&format!("{s1_umi}{s1_barcode}{s1_cellular_barcode}{template}")],
+        )];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        // template_types includes C (cellular barcode) and T; output should be C+T (82 bp).
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['C', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+
+        let output_path = output_dir.join("Sample0000.R1.fq.gz");
+        let fq_reads = read_fastq(&output_path);
+
+        assert_eq!(fq_reads.len(), 1);
+        let expected_seq = s1_cellular_barcode.to_owned() + &template;
+        assert_equal(
+            &fq_reads[0],
+            &OwnedRecord {
+                head: b"ex_0:ATCGATCGAT 1:N:0:AAAAAAAA".to_vec(),
+                seq: expected_seq.as_bytes().to_vec(),
+                qual: ";".repeat(82).as_bytes().to_vec(),
             },
         );
     }
@@ -1533,7 +1936,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1610,7 +2013,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1667,7 +2070,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1741,7 +2144,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1814,7 +2217,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -1880,7 +2283,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux.execute().unwrap();
 
@@ -1945,7 +2348,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux.execute().unwrap();
 
@@ -2010,7 +2413,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -2085,7 +2488,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -2120,7 +2523,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -2155,7 +2558,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -2195,7 +2598,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
     }
@@ -2232,7 +2635,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![SkipReason::TooFewBases],
-            no_trim: false,
+            template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
@@ -2259,8 +2662,16 @@ mod tests {
     ////////////////////////////////////////////////////////////////////////////
 
     fn seg(bases: &[u8], segment_type: SegmentType) -> FastqSegment {
+        seg_with_source(bases, segment_type, 0)
+    }
+
+    fn seg_with_source(
+        bases: &[u8],
+        segment_type: SegmentType,
+        source_index: usize,
+    ) -> FastqSegment {
         let quals = vec![b'#'; bases.len()];
-        FastqSegment { seq: bases.to_vec(), quals, segment_type, source_index: 0 }
+        FastqSegment { seq: bases.to_vec(), quals, segment_type, source_index }
     }
 
     #[test]
@@ -2503,5 +2914,47 @@ mod tests {
     #[should_panic(expected = "Cannot call combine readsets on an empty vec!")]
     fn test_combine_readsets_fails_on_empty_vector() {
         let _result = ReadSet::combine_readsets(Vec::new());
+    }
+
+    #[test]
+    fn test_segments_for_source() {
+        // Build a ReadSet with segments from two source indices in interleaved order so we can
+        // verify segments_for_source filters by source AND preserves the original ordering.
+        let segments = vec![
+            seg_with_source(b"AAAA", SegmentType::SampleBarcode, 0),
+            seg_with_source(b"GGGGG", SegmentType::Template, 0),
+            seg_with_source(b"CC", SegmentType::MolecularBarcode, 1),
+            seg_with_source(b"TTT", SegmentType::Template, 1),
+            seg_with_source(b"NN", SegmentType::Skip, 0),
+        ];
+        let rs = read_set(segments);
+
+        let b_t: HashSet<SegmentType> =
+            [SegmentType::SampleBarcode, SegmentType::Template].into_iter().collect();
+        let m_t: HashSet<SegmentType> =
+            [SegmentType::MolecularBarcode, SegmentType::Template].into_iter().collect();
+        let t_only: HashSet<SegmentType> = [SegmentType::Template].into_iter().collect();
+
+        // Source 0 with {B,T}: pick segments at original positions 0 and 1 in order.
+        let (seq, quals) = rs.segments_for_source(0, &b_t);
+        assert_eq!(seq, b"AAAAGGGGG");
+        assert_eq!(quals.len(), seq.len());
+
+        // Source 1 with {M,T}: pick segments at original positions 2 and 3 in order.
+        let (seq, _) = rs.segments_for_source(1, &m_t);
+        assert_eq!(seq, b"CCTTT");
+
+        // Source 0 with {T}: only the template segment.
+        let (seq, _) = rs.segments_for_source(0, &t_only);
+        assert_eq!(seq, b"GGGGG");
+
+        // Source 0 with {M,T}: source 0 has no M, so just the T.
+        let (seq, _) = rs.segments_for_source(0, &m_t);
+        assert_eq!(seq, b"GGGGG");
+
+        // Unused source index returns empty.
+        let (seq, quals) = rs.segments_for_source(2, &b_t);
+        assert!(seq.is_empty());
+        assert!(quals.is_empty());
     }
 }

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -46,6 +46,8 @@ struct FastqSegment {
     quals: Vec<u8>,
     /// the type of segment being stored
     segment_type: SegmentType,
+    /// the index of the source FASTQ file this segment came from
+    source_index: usize,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -136,6 +138,20 @@ impl ReadSet {
         }
 
         first
+    }
+
+    /// Reconstructs the original (untrimmed) read for a given source index by concatenating
+    /// all segments from that source in order. Used for --no-trim output.
+    fn original_read_for_source(&self, source_index: usize) -> (Vec<u8>, Vec<u8>) {
+        let mut seq = Vec::new();
+        let mut quals = Vec::new();
+        for segment in &self.segments {
+            if segment.source_index == source_index {
+                seq.extend_from_slice(&segment.seq);
+                quals.extend_from_slice(&segment.quals);
+            }
+        }
+        (seq, quals)
     }
 
     /// Writes the FASTQ header to the given writer.  Substitutes in the given read number into
@@ -280,6 +296,8 @@ struct ReadSetIterator {
     source: FastqReader<Box<dyn BufRead + Send>>,
     /// Valid reasons for skipping reads, otherwise panic!
     skip_reasons: Vec<SkipReason>,
+    /// The index of this FASTQ source (0-based), used for tracking original reads.
+    source_index: usize,
 }
 
 impl Iterator for ReadSetIterator {
@@ -333,6 +351,7 @@ impl Iterator for ReadSetIterator {
                     seq: seq.to_vec(),
                     quals: quals.to_vec(),
                     segment_type: read_segment.kind,
+                    source_index: self.source_index,
                 });
             }
             Some(ReadSet { header: read_name.to_vec(), segments, skip_reason: None })
@@ -344,13 +363,14 @@ impl Iterator for ReadSetIterator {
 
 impl ReadSetIterator {
     /// Instantiates a new iterator over the read sets for a set of FASTQs with defined read
-    /// structures
+    /// structures.
     pub fn new(
         read_structure: ReadStructure,
         source: FastqReader<Box<dyn BufRead + Send>>,
         skip_reasons: Vec<SkipReason>,
+        source_index: usize,
     ) -> Self {
-        Self { read_structure, source, skip_reasons }
+        Self { read_structure, source, skip_reasons, source_index }
     }
 }
 
@@ -393,9 +413,35 @@ impl<W: Write> SampleWriters<W> {
     /// ``Self`` struct.
     /// Reads in the read set should be 1:1 with writers in the writer set however this is not
     /// checked at runtime as doing so substantially slows demulitplexing.
-    fn write(&mut self, read_set: &ReadSet) -> Result<()> {
+    ///
+    /// If `no_trim` is true, template outputs will contain the full original reads instead of
+    /// just the template segments.
+    fn write(&mut self, read_set: &ReadSet, no_trim: bool) -> Result<()> {
+        // Handle template writers separately to support no_trim
+        if let Some(writers) = &mut self.template_writers {
+            for (read_idx, (writer, segment)) in
+                writers.iter_mut().zip(read_set.template_segments()).enumerate()
+            {
+                read_set.write_header(writer, read_idx + 1)?;
+                writer.write_all(b"\n")?;
+                if no_trim {
+                    // Write the original untrimmed read by reconstructing from segments
+                    let (seq, quals) = read_set.original_read_for_source(segment.source_index);
+                    writer.write_all(&seq)?;
+                    writer.write_all(b"\n+\n")?;
+                    writer.write_all(&quals)?;
+                } else {
+                    // Write just the template segment
+                    writer.write_all(segment.seq.as_slice())?;
+                    writer.write_all(b"\n+\n")?;
+                    writer.write_all(segment.quals.as_slice())?;
+                }
+                writer.write_all(b"\n")?;
+            }
+        }
+
+        // Handle other segment types (barcodes, UMIs, etc.) - always write segments, not originals
         for (writers_opt, segments) in [
-            (&mut self.template_writers, &mut read_set.template_segments()),
             (&mut self.sample_barcode_writers, &mut read_set.sample_barcode_segments()),
             (&mut self.molecular_barcode_writers, &mut read_set.molecular_barcode_segments()),
             (&mut self.cellular_barcode_writers, &mut read_set.cellular_barcode_segments()),
@@ -649,6 +695,12 @@ pub(crate) struct Demux {
     ///    if a read is empty and the read structure is `+T`.
     #[clap(long, short = 'S')]
     skip_reasons: Vec<SkipReason>,
+
+    /// Output the original untrimmed reads in the template FASTQ files instead of just the
+    /// template segments. The read structure is still used for barcode extraction/matching,
+    /// but template outputs will contain the full original read.
+    #[clap(long)]
+    no_trim: bool,
 }
 
 impl Demux {
@@ -927,9 +979,15 @@ impl Command for Demux {
 
         let mut fq_iterators = fq_sources
             .zip(self.read_structures.clone())
-            .map(|(source, read_structure)| {
-                ReadSetIterator::new(read_structure, source, self.skip_reasons.clone())
-                    .read_ahead(1000, 1000)
+            .enumerate()
+            .map(|(source_index, (source, read_structure))| {
+                ReadSetIterator::new(
+                    read_structure,
+                    source,
+                    self.skip_reasons.clone(),
+                    source_index,
+                )
+                .read_ahead(1000, 1000)
             })
             .collect::<Vec<_>>();
 
@@ -967,10 +1025,10 @@ impl Command for Demux {
             let read_set = ReadSet::combine_readsets(next_read_sets);
             if let Some(barcode_match) = barcode_matcher.assign(&read_set.sample_barcode_sequence())
             {
-                sample_writers[barcode_match.best_match].write(&read_set)?;
+                sample_writers[barcode_match.best_match].write(&read_set, self.no_trim)?;
                 sample_metrics[barcode_match.best_match].templates += 1;
             } else {
-                sample_writers[unmatched_index].write(&read_set)?;
+                sample_writers[unmatched_index].write(&read_set, self.no_trim)?;
                 unmatched_metric.templates += 1;
             }
             logger.record();
@@ -1130,6 +1188,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1173,6 +1232,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1212,6 +1272,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         let demux_result = demux_inputs.execute();
         permissions.set_readonly(false);
@@ -1250,6 +1311,7 @@ mod tests {
             threads: 2,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1285,6 +1347,7 @@ mod tests {
             threads: 2,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1315,6 +1378,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1327,6 +1391,111 @@ mod tests {
             &OwnedRecord {
                 head: b"ex_0 1:N:0:AAAAAAAAGATTACAGA".to_vec(),
                 seq: "A".repeat(100).as_bytes().to_vec(),
+                qual: ";".repeat(100).as_bytes().to_vec(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_no_trim_outputs_original_reads() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("17B100T").unwrap()];
+        let s1_barcode = "AAAAAAAAGATTACAGA";
+        let template_seq = "T".repeat(100);
+        let full_read = s1_barcode.to_owned() + &template_seq;
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &[&full_read])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            no_trim: true,
+        };
+        demux_inputs.execute().unwrap();
+
+        let output_path = output_dir.join("Sample0000.R1.fq.gz");
+        let fq_reads = read_fastq(&output_path);
+
+        assert_eq!(fq_reads.len(), 1);
+        // With no_trim, the output should be the full original read (barcode + template)
+        assert_equal(
+            &fq_reads[0],
+            &OwnedRecord {
+                head: b"ex_0 1:N:0:AAAAAAAAGATTACAGA".to_vec(),
+                seq: full_read.as_bytes().to_vec(),
+                qual: ";".repeat(117).as_bytes().to_vec(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_no_trim_with_paired_reads() {
+        let tmp = TempDir::new().unwrap();
+        // R1 has inline barcode, R2 is pure template
+        let read_structures = vec![
+            ReadStructure::from_str("8B92T").unwrap(),
+            ReadStructure::from_str("100T").unwrap(),
+        ];
+        let s1_barcode = "AAAAAAAA";
+        let r1_full = s1_barcode.to_owned() + &"A".repeat(92);
+        let r2_full = "T".repeat(100);
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![
+            fastq_file(&tmp, "ex_R1", "ex", &[&r1_full]),
+            fastq_file(&tmp, "ex_R2", "ex", &[&r2_full]),
+        ];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            no_trim: true,
+        };
+        demux_inputs.execute().unwrap();
+
+        // R1 output should be full 100bp read (barcode + template)
+        let r1_path = output_dir.join("Sample0000.R1.fq.gz");
+        let r1_reads = read_fastq(&r1_path);
+        assert_eq!(r1_reads.len(), 1);
+        assert_equal(
+            &r1_reads[0],
+            &OwnedRecord {
+                head: b"ex_0 1:N:0:AAAAAAAA".to_vec(),
+                seq: r1_full.as_bytes().to_vec(),
+                qual: ";".repeat(100).as_bytes().to_vec(),
+            },
+        );
+
+        // R2 output should be full 100bp read (same as template since no barcode)
+        let r2_path = output_dir.join("Sample0000.R2.fq.gz");
+        let r2_reads = read_fastq(&r2_path);
+        assert_eq!(r2_reads.len(), 1);
+        assert_equal(
+            &r2_reads[0],
+            &OwnedRecord {
+                head: b"ex_0 2:N:0:AAAAAAAA".to_vec(),
+                seq: r2_full.as_bytes().to_vec(),
                 qual: ";".repeat(100).as_bytes().to_vec(),
             },
         );
@@ -1364,6 +1533,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1440,6 +1610,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1496,6 +1667,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1569,6 +1741,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1641,6 +1814,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1706,6 +1880,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux.execute().unwrap();
 
@@ -1770,6 +1945,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux.execute().unwrap();
 
@@ -1834,6 +2010,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -1908,6 +2085,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1942,6 +2120,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -1976,6 +2155,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -2015,6 +2195,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
     }
@@ -2051,6 +2232,7 @@ mod tests {
             threads: 5,
             compression_level: 5,
             skip_reasons: vec![SkipReason::TooFewBases],
+            no_trim: false,
         };
         demux_inputs.execute().unwrap();
 
@@ -2078,7 +2260,7 @@ mod tests {
 
     fn seg(bases: &[u8], segment_type: SegmentType) -> FastqSegment {
         let quals = vec![b'#'; bases.len()];
-        FastqSegment { seq: bases.to_vec(), quals, segment_type }
+        FastqSegment { seq: bases.to_vec(), quals, segment_type, source_index: 0 }
     }
 
     #[test]

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -182,13 +182,23 @@ impl ReadSet {
     /// Where
     ///   name = @<instrument>:<run number>:<flowcell ID>:<lane>:<tile>:<x-pos>:<y-pos>:<UMI>
     ///   comment = <read>:<is filtered>:<control number>:<index>
-    fn write_header<W: Write>(&self, writer: &mut W, read_num: usize) -> Result<()> {
+    ///
+    /// When `include_umi` is false, UMI (M) segments are not folded into the read name; this is
+    /// used when the UMI bases are instead written into the template output bases, to avoid
+    /// emitting the same bases in both the header and the bases.
+    fn write_header<W: Write>(
+        &self,
+        writer: &mut W,
+        read_num: usize,
+        include_umi: bool,
+    ) -> Result<()> {
         Self::write_header_internal(
             writer,
             read_num,
             self.header.as_slice(),
             self.sample_barcode_segments(),
             self.molecular_barcode_segments(),
+            include_umi,
         )
     }
 
@@ -198,6 +208,7 @@ impl ReadSet {
         header: &[u8],
         sample_barcode_segments: SegmentIter,
         mut molecular_barcode_segments: SegmentIter,
+        include_umi: bool,
     ) -> Result<()> {
         // Extract the name and optionally the comment
         let (name, comment) = match header.find_byte(Self::SPACE) {
@@ -207,9 +218,11 @@ impl ReadSet {
 
         writer.write_all(&[Self::PREFIX])?;
 
-        // Handle the 'name' component of the header.  If we don't have any UMI segments
-        // we can emit the name part as is.  Otherwise we need to append the UMIs to the name.
-        if let Some(first_seg) = molecular_barcode_segments.next() {
+        // Handle the 'name' component of the header.  If we don't have any UMI segments (or UMIs
+        // are being written into the template bases instead) we can emit the name part as is.
+        // Otherwise we need to append the UMIs to the name.
+        let first_umi_segment = if include_umi { molecular_barcode_segments.next() } else { None };
+        if let Some(first_seg) = first_umi_segment {
             let sep_count = name.iter().filter(|c| **c == Self::COLON).count();
             ensure!(
                 sep_count <= 7,
@@ -383,6 +396,32 @@ impl ReadSetIterator {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// TemplateOutput
+////////////////////////////////////////////////////////////////////////////////
+
+/// How segments are routed into the template output bases and the read header, derived once from
+/// `--template-types` and reused for every record.
+struct TemplateOutput {
+    /// Segment types to concatenate into the template read bases. Always includes Template (T).
+    types: HashSet<SegmentType>,
+    /// Whether any non-template segment types are folded into the template bases. When false, the
+    /// template writer emits just the template segment (the default behavior).
+    include_other_segments: bool,
+    /// Whether UMI (M) segments should be written into the read header. False when UMIs are folded
+    /// into the template bases, so the same bases are not written in both the header and the bases.
+    umi_in_header: bool,
+}
+
+impl TemplateOutput {
+    /// Derives the template output routing from the set of `--template-types` segment types.
+    fn from_types(types: HashSet<SegmentType>) -> Self {
+        let include_other_segments = types.iter().any(|t| *t != SegmentType::Template);
+        let umi_in_header = !types.contains(&SegmentType::MolecularBarcode);
+        Self { types, include_other_segments, umi_in_header }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // SampleWriters and it's impls
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -422,24 +461,22 @@ impl<W: Write> SampleWriters<W> {
     /// Reads in the read set should be 1:1 with writers in the writer set however this is not
     /// checked at runtime as doing so substantially slows demulitplexing.
     ///
-    /// The `template_types` parameter specifies which segment types to include in the template
-    /// output. If it contains only Template, only template segments are written. If it contains
-    /// additional types (e.g. MolecularBarcode), those segments are concatenated with the template.
-    fn write(&mut self, read_set: &ReadSet, template_types: &HashSet<SegmentType>) -> Result<()> {
-        // Handle template writers separately to support template_types
+    /// The `template` parameter specifies how segments are routed into the template output. If it
+    /// includes only Template, only template segments are written. If it includes additional types
+    /// (e.g. MolecularBarcode), those segments are concatenated with the template, and UMIs are
+    /// omitted from the read header so the same bases are not written twice.
+    fn write(&mut self, read_set: &ReadSet, template: &TemplateOutput) -> Result<()> {
+        // Handle template writers separately to support template output routing
         if let Some(writers) = &mut self.template_writers {
-            // Check if we need to include non-template segments
-            let include_other_segments = template_types.iter().any(|t| *t != SegmentType::Template);
-
             for (read_idx, (writer, segment)) in
                 writers.iter_mut().zip(read_set.template_segments()).enumerate()
             {
-                read_set.write_header(writer, read_idx + 1)?;
+                read_set.write_header(writer, read_idx + 1, template.umi_in_header)?;
                 writer.write_all(b"\n")?;
-                if include_other_segments {
+                if template.include_other_segments {
                     // Write segments of the requested types from this source
                     let (seq, quals) =
-                        read_set.segments_for_source(segment.source_index, template_types);
+                        read_set.segments_for_source(segment.source_index, &template.types);
                     writer.write_all(&seq)?;
                     writer.write_all(b"\n+\n")?;
                     writer.write_all(&quals)?;
@@ -461,7 +498,7 @@ impl<W: Write> SampleWriters<W> {
         ] {
             if let Some(writers) = writers_opt {
                 for (read_idx, (writer, segment)) in writers.iter_mut().zip(segments).enumerate() {
-                    read_set.write_header(writer, read_idx + 1)?;
+                    read_set.write_header(writer, read_idx + 1, template.umi_in_header)?;
                     writer.write_all(b"\n")?;
                     writer.write_all(segment.seq.as_slice())?;
                     writer.write_all(b"\n+\n")?;
@@ -712,14 +749,22 @@ pub(crate) struct Demux {
     /// The read structure types to include in the template FASTQ output files.
     ///
     /// By default, only template (T) segments are included. To include additional segment types
-    /// (e.g. to preserve UMIs in the output reads), specify them here. For example,
-    /// `--template-types M T` will include both molecular barcode and template segments.
+    /// (e.g. to preserve UMIs in the output read bases), specify them here. For example,
+    /// `--template-types M T` will concatenate the molecular barcode and template segments.
     ///
     /// To output the full original reads (all segments), specify all segment types present in
     /// your read structure (e.g. `--template-types B M T`).
     ///
+    /// Segments are only merged *within the same physical read*: a non-`T` segment is folded into
+    /// the template bases only when it is co-located with a `T` in the same read structure (e.g.
+    /// `8M84T`). A segment on a separate read (e.g. a UMI on its own index read) is never merged
+    /// into a template on another read; route it via `--output-types` instead, or leave it in the
+    /// read header. When a UMI (M) is included here it is written into the template bases and is
+    /// therefore omitted from the read header (it is not written in both places).
+    ///
     /// Note: If `--template-types` includes any non-`T` type, `T` must be included in
-    /// `--output-types`, and each read structure must contain at most one `T` segment.
+    /// `--output-types`; each requested non-`T` type must be co-located with a `T` in every read
+    /// structure where it appears; and each read structure must contain at most one `T` segment.
     #[clap(long, default_value = "T", num_args = 1..)]
     template_types: Vec<char>,
 }
@@ -881,7 +926,7 @@ impl Demux {
         match chars.iter().map(|&c| SegmentType::try_from(c)).collect::<Result<HashSet<_>, _>>() {
             Ok(set) => Some(set),
             Err(e) => {
-                errors.push(format!("{}: {}", error_prefix, e));
+                errors.push(format!("{error_prefix}: {e}"));
                 None
             }
         }
@@ -966,20 +1011,52 @@ impl Demux {
                     }
                 }
 
-                // Each requested non-T type must appear in at least one read structure, else the
-                // request is silently a no-op (segments_for_source emits only the template).
+                // A non-T type is folded into the template bases only when it is co-located with
+                // a T in the *same* physical read; segments are never merged across reads. Require
+                // each requested non-T type to (a) appear in at least one read structure, and (b)
+                // share every read structure it appears in with a T. Otherwise its bases would be
+                // neither merged into a template nor written anywhere, i.e. silently dropped.
                 for segment_type in template_types.iter().filter(|t| **t != SegmentType::Template) {
-                    let present = self
+                    let type_char = segment_type.value();
+                    let present_anywhere = self
                         .read_structures
                         .iter()
                         .any(|rs| rs.segments_by_type(*segment_type).count() > 0);
-                    if !present {
+                    if !present_anywhere {
                         constraint_errors.push(format!(
-                            "--template-types includes {} but no read structure contains that segment type",
-                            segment_type.value()
+                            "--template-types includes {type_char} but no read structure contains that segment type"
                         ));
+                        continue;
+                    }
+                    for (idx, rs) in self.read_structures.iter().enumerate() {
+                        let has_type = rs.segments_by_type(*segment_type).count() > 0;
+                        let has_template = rs.segments_by_type(SegmentType::Template).count() > 0;
+                        if has_type && !has_template {
+                            constraint_errors.push(format!(
+                                "--template-types includes {type_char} but read structure #{} contains {type_char} with no template (T) segment to merge it into (segments are only merged within the same read); add {type_char} to --output-types, or remove it from --template-types so it is written to the read header instead",
+                                idx + 1
+                            ));
+                        }
                     }
                 }
+            }
+
+            // Every segment type present in the read structures must have a destination so its
+            // bases are not silently lost. Template (T) is forced into output, sample barcode (B)
+            // and molecular barcode (M) fall back to the read header, and Skip (S) is discarded by
+            // design. Cellular barcode (C) has no read-header field, so it must be routed
+            // explicitly to either an output file or the template bases.
+            let cellular_present = self
+                .read_structures
+                .iter()
+                .any(|rs| rs.segments_by_type(SegmentType::CellularBarcode).count() > 0);
+            if cellular_present
+                && !output_types.contains(&SegmentType::CellularBarcode)
+                && !template_types.contains(&SegmentType::CellularBarcode)
+            {
+                constraint_errors.push(
+                    "Cellular barcode (C) segments are present but assigned to neither --output-types nor --template-types, and have no read-header field; add C to one of them".to_owned(),
+                );
             }
         }
 
@@ -1034,6 +1111,7 @@ impl Command for Demux {
     fn execute(&self) -> Result<()> {
         let (fq_readers, output_segment_types, template_segment_types) =
             self.validate_and_prepare_inputs()?;
+        let template_output = TemplateOutput::from_types(template_segment_types);
 
         let sample_group = SampleGroup::from_file(&self.sample_metadata)?;
         info!(
@@ -1127,11 +1205,10 @@ impl Command for Demux {
             let read_set = ReadSet::combine_readsets(next_read_sets);
             if let Some(barcode_match) = barcode_matcher.assign(&read_set.sample_barcode_sequence())
             {
-                sample_writers[barcode_match.best_match]
-                    .write(&read_set, &template_segment_types)?;
+                sample_writers[barcode_match.best_match].write(&read_set, &template_output)?;
                 sample_metrics[barcode_match.best_match].templates += 1;
             } else {
-                sample_writers[unmatched_index].write(&read_set, &template_segment_types)?;
+                sample_writers[unmatched_index].write(&read_set, &template_output)?;
                 unmatched_metric.templates += 1;
             }
             logger.record();
@@ -1639,12 +1716,14 @@ mod tests {
         let fq_reads = read_fastq(&output_path);
 
         assert_eq!(fq_reads.len(), 1);
-        // With template_types M T, the output should be UMI + template (no barcode)
+        // With template_types M T, the output bases should be UMI + template (no barcode). Because
+        // the UMI is written into the bases, it is *not* also appended to the read name (no
+        // trailing `:GGGGGGGG` on the name), so the same bases are not emitted twice.
         let expected_seq = umi.to_owned() + &template;
         assert_equal(
             &fq_reads[0],
             &OwnedRecord {
-                head: b"ex_0:GGGGGGGG 1:N:0:AAAAAAAA".to_vec(),
+                head: b"ex_0 1:N:0:AAAAAAAA".to_vec(),
                 seq: expected_seq.as_bytes().to_vec(),
                 qual: ";".repeat(92).as_bytes().to_vec(),
             },
@@ -1808,6 +1887,75 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(
+        expected = "--template-types includes M but read structure #1 contains M with no template (T) segment to merge it into"
+    )]
+    fn test_template_types_non_colocated_segment_rejected() {
+        let tmp = TempDir::new().unwrap();
+        // The UMI (M) is on its own read (R1), separate from the template (R2). Since segments are
+        // only merged within the same read, M cannot be folded into the template and the request
+        // must be rejected rather than silently dropping the UMI bases.
+        let read_structures =
+            vec![ReadStructure::from_str("8M").unwrap(), ReadStructure::from_str("100T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![
+            fastq_file(&tmp, "r1", "r1", &["GGGGGGGG"]),
+            fastq_file(&tmp, "r2", "r2", &["A".repeat(100).as_str()]),
+        ];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['M', 'T'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Cellular barcode (C) segments are present but assigned to neither --output-types nor --template-types"
+    )]
+    fn test_cellular_barcode_without_destination_rejected() {
+        let tmp = TempDir::new().unwrap();
+        // A cellular barcode (C) is present but routed to neither --output-types nor
+        // --template-types, and has no read-header field, so its bases would be silently lost.
+        let read_structures = vec![ReadStructure::from_str("8B7C85T").unwrap()];
+        let s1_barcode = "AAAAAAAA";
+        let sample_metadata = metadata_file(&tmp, &[s1_barcode]);
+        let input_files = vec![fastq_file(&tmp, "ex", "ex", &["A".repeat(100).as_str()])];
+
+        let output_dir = tmp.path().to_path_buf().join("output");
+
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['T'],
+        };
+        demux_inputs.execute().unwrap();
+    }
+
+    #[test]
     fn test_template_types_all_segments_with_skip() {
         let tmp = TempDir::new().unwrap();
         // Read structure with barcode, skip, UMI, and template
@@ -1843,11 +1991,12 @@ mod tests {
         let fq_reads = read_fastq(&output_path);
 
         assert_eq!(fq_reads.len(), 1);
-        // With all template_types, the output should be the full original read
+        // With all template_types, the output should be the full original read. The UMI (M) is
+        // folded into the bases, so it is not also appended to the read name.
         assert_equal(
             &fq_reads[0],
             &OwnedRecord {
-                head: b"ex_0:GGGGGGGG 1:N:0:AAAAAAAA".to_vec(),
+                head: b"ex_0 1:N:0:AAAAAAAA".to_vec(),
                 seq: full_read.as_bytes().to_vec(),
                 qual: ";".repeat(100).as_bytes().to_vec(),
             },
@@ -2688,6 +2837,7 @@ mod tests {
             header,
             barcode_segs.iter().filter(|_| true),
             umi_segs.iter().filter(|_| true),
+            true,
         )
         .unwrap();
         assert_eq!(String::from_utf8(out).unwrap(), expected);
@@ -2707,6 +2857,29 @@ mod tests {
             header,
             barcode_segs.iter().filter(|_| true),
             umi_segs.iter().filter(|_| true),
+            true,
+        )
+        .unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_write_header_omits_umi_when_in_template_bases() {
+        // When include_umi is false (UMI bases are written into the template output instead), the
+        // UMI must not be appended to the read name, but sample barcodes are still appended.
+        let mut out = Vec::new();
+        let header = b"inst:123:ABCDE:1:204:1022:2108 1:Y:0:0";
+        let barcode_segs =
+            [seg(b"ACGT", SegmentType::SampleBarcode), seg(b"GGTT", SegmentType::SampleBarcode)];
+        let umi_segs = [seg(b"AACCGGTT", SegmentType::MolecularBarcode)];
+        let expected = "@inst:123:ABCDE:1:204:1022:2108 2:Y:0:ACGT+GGTT".to_string();
+        ReadSet::write_header_internal(
+            &mut out,
+            2,
+            header,
+            barcode_segs.iter().filter(|_| true),
+            umi_segs.iter().filter(|_| true),
+            false,
         )
         .unwrap();
         assert_eq!(String::from_utf8(out).unwrap(), expected);
@@ -2727,6 +2900,7 @@ mod tests {
             header,
             barcode_segs.iter().filter(|_| true),
             umi_segs.iter().filter(|_| true),
+            true,
         )
         .unwrap();
         assert_eq!(String::from_utf8(out).unwrap(), expected);
@@ -2746,6 +2920,7 @@ mod tests {
             header,
             barcode_segs.iter().filter(|_| true),
             umi_segs.iter().filter(|_| true),
+            true,
         )
         .unwrap();
         assert_eq!(String::from_utf8(out).unwrap(), expected);
@@ -2765,6 +2940,7 @@ mod tests {
             header,
             barcode_segs.iter().filter(|_| true),
             umi_segs.iter().filter(|_| true),
+            true,
         )
         .unwrap();
     }
@@ -2783,6 +2959,7 @@ mod tests {
             header,
             barcode_segs.iter().filter(|_| true),
             umi_segs.iter().filter(|_| true),
+            true,
         )
         .unwrap();
         assert_eq!(String::from_utf8(out).unwrap(), expected);

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -53,11 +53,7 @@ pub fn encode(bases: &[u8]) -> BitEnc {
             IUPAC_MASKS[b'N' as usize]
         } else {
             let value = base.to_ascii_uppercase() as usize;
-            if value < 256 {
-                IUPAC_MASKS[value]
-            } else {
-                0
-            }
+            if value < 256 { IUPAC_MASKS[value] } else { 0 }
         };
         vec.push(bit);
     }


### PR DESCRIPTION
## Summary

Adds a `--template-types` option to the `demux` command that controls which read-structure segment types are concatenated into the template FASTQ output, replacing the original binary `--no-trim` concept with finer-grained control.

- Default is `--template-types T` (only template segments, matching prior behavior).
- Include additional segments to preserve them in the read bases: `--template-types M T` keeps UMI + template.
- Output the full original reads with `--template-types B S M T`.

## Routing model

Segments are routed so that **each segment's bases appear in exactly one place**:

- `--template-types` selects which types are concatenated into the template read bases. Segments are only merged **within the same physical read**: a non-`T` type is folded into the template only when it is co-located with a `T` in the same read structure (e.g. `8M84T`). A segment on a separate read (e.g. a UMI on its own index read) is never merged into a template on another read.
- `--output-types` selects which types are written to their own files (`R`/`I`/`U`/`C`).
- Anything not written to an output file falls back to the read header: UMIs (`M`) to the UMI field, sample barcodes (`B`) to the index field.

A consequence of this model: when a UMI is folded into the template bases via `--template-types M T`, it is **no longer also injected into the read header**, so the same bases are not emitted in both places.

## Validation

Up-front validation rejects configurations that would otherwise silently drop bases or produce surprising output:

- `--template-types` must include `T`.
- If `--template-types` includes any non-`T` type, `T` must be in `--output-types`.
- Each requested non-`T` type must be co-located with a `T` in **every** read structure where it appears (segments are merged only within a read).
- No read structure may contain more than one `T` segment when `--template-types` has non-`T` types.
- A cellular barcode (`C`) that is present but routed to neither `--output-types` nor `--template-types` is rejected, since `C` has no read-header field and its bases would otherwise be lost.

## Use Case

| Read Structure | Command | Template output |
|---------------|---------|--------|
| `8B8M84T` | (default) | 84 bp template only; UMI in header |
| `8B8M84T` | `--template-types M T` | 92 bp (UMI + template); UMI in bases, not header |
| `8B8M84T` | `--template-types B M T` | 100 bp (full read) |

## Test Plan

- [x] `test_template_types_includes_barcode` — B+T output
- [x] `test_template_types_with_paired_reads` — paired-end behavior
- [x] `test_template_types_with_umi` — M+T in bases, UMI removed from header (no double-write)
- [x] `test_template_types_all_segments_with_skip` — full read; UMI in bases, not header
- [x] `test_template_types_with_cellular_barcode` — C+T output
- [x] `test_write_header_omits_umi_when_in_template_bases` — header suppression unit test
- [x] `test_template_types_non_colocated_segment_rejected` — UMI on a separate read is rejected
- [x] `test_cellular_barcode_without_destination_rejected` — unrouted C is rejected
- [x] `test_template_types_requires_template_in_output_types`, `test_template_types_must_include_template`, `test_template_types_non_t_rejects_multi_template_read_structure`, `test_template_types_absent_type_rejected`, `test_template_types_invalid_segment_type` — validation
- [x] All existing tests pass; `README.md` usage block updated to match `--help`

Closes #59
