### PR TITLE
build: update CI actions to latest versions and pin by commit hash

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,7 +2,7 @@ name: Check
 
 on: [push, pull_request]
 
-env: 
+env:
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -11,26 +11,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install stable toolchain
-        uses: codota/toolchain@00a8bf2bdcfe93aefd70422d3dec07337959d3a4 # v1
-        with:
-          profile: minimal
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+
       - name: Run cargo check
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: check
+        run: cargo check
 
       - name: Run cargo build
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: build
+        run: cargo build
 
       - name: Append usage to the README.md
         shell: bash
@@ -62,17 +55,13 @@ jobs:
         os: [ubuntu-24.04, macOS-latest]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install stable toolchain
-        uses: codota/toolchain@00a8bf2bdcfe93aefd70422d3dec07337959d3a4 # v1
-        with:
-          profile: minimal
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
       - name: Run tests
         run: bash src/scripts/precommit.sh
-

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,7 +2,7 @@ name: Check
 
 on: [push, pull_request]
 
-env: 
+env:
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -11,26 +11,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install stable toolchain
-        uses: codota/toolchain@00a8bf2bdcfe93aefd70422d3dec07337959d3a4 # v1
-        with:
-          profile: minimal
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
       - name: Run cargo check
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: check
+        run: cargo check
 
       - name: Run cargo build
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: build
+        run: cargo build
 
       - name: Append usage to the README.md
         shell: bash
@@ -62,17 +55,13 @@ jobs:
         os: [ubuntu-24.04, macOS-latest]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install stable toolchain
-        uses: codota/toolchain@00a8bf2bdcfe93aefd70422d3dec07337959d3a4 # v1
-        with:
-          profile: minimal
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Run tests
         run: bash ci/check.sh
-


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` from v4 to **v6.0.2**
- Replace `codota/toolchain@v1` with `dtolnay/rust-toolchain@stable` — codota/toolchain is unmaintained and emits `set-output` deprecation warnings that will become errors when GitHub disables the command
- Replace `actions-rs/cargo@v1` with direct `cargo` commands — actions-rs is also unmaintained and adds unnecessary indirection
- Bump `Swatinem/rust-cache` to **v2.9.1**
- Pin every action by full commit hash with a trailing `# vX.Y.Z` (or `# stable`) comment, per repo policy

## Pinned versions

| Action | Hash | Version |
|---|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `dtolnay/rust-toolchain` | `29eef336d9b2848a0b548edc03f92a220660cdb8` | stable |
| `Swatinem/rust-cache` | `23869a5bd66c73db3c0ac40331f3206eb23791dc` | v2.9.1 |

## Test plan
- [ ] CI passes on this PR (the workflow changes are self-testing)