### PR TITLE
feat: support per-sample read structures in `fqtk demux`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,46 @@ The expected barcode sequence may contains Ns, which are not counted as mismatch
 of the observed base (e.g. the expected barcode `AAN` will have zero mismatches relative to
 both the observed barcodes `AAA` and `AAN`).
 
+## Per-sample read structures
+
+In addition to the global `--read-structures`, the metadata TSV may include optional columns
+`read_structure_1`, `read_structure_2`, ..., `read_structure_<N>` (where `N` is the number of
+input FASTQs).  When any cell is non-empty for a sample, the per-sample read structures
+replace the global `--read-structures` for that sample — both for matching and for output
+extraction.
+
+Per-sample structures support per-cell fall-back to the global `--read-structures`:
+
+- A blank `read_structure_<i>` cell uses `--read-structures[i-1]` for that sample's input *i*.
+- A row whose `read_structure_<n>` cells are all blank uses `--read-structures` entirely for
+  that sample (equivalent to omitting the columns for that sample only).
+- The unmatched pseudo-sample always uses the global `--read-structures`.
+
+Constraints:
+
+1. The number of `read_structure_<n>` columns must equal `--read-structures.len()`.
+2. The concatenated `B`-segment length must equal the `barcode` column length for every
+   sample (computed from each sample's *effective* read structures, i.e. with fall-backs
+   applied).
+
+Different samples may have different per-input `(T, B, M, C)` segment counts (and hence
+produce different sets of output files).  This supports protocols with sample-dependent
+read structures (e.g. CODEC, where each sample may include a stagger spacer of varying
+length so that the position of the constant ligation base shifts per sample).
+
+During matching, each sample's expected pattern is constructed from its effective read
+structure by filling `B`-segment positions from the `barcode` column and treating
+`M`/`S`/`C` segment positions as `N` wildcards.  All patterns are padded with trailing `N`s
+to a per-input matching window equal to the longest pre-template prefix across samples.
+
+Example metadata TSV (CODEC stagger):
+
+```text
+sample_id  barcode         read_structure_1   read_structure_2
+S1         GATTACAGATTACA  3M7B1S+T           3M7B1S+T
+S2         TTTTTTTTTTTTTT  3M1S7B1S+T         3M1S7B1S+T
+```
+
 ## Outputs
 
 All outputs are generated in the provided `--output` directory.  For each sample plus the
@@ -136,7 +176,9 @@ Options:
           One or more input FASTQ files each corresponding to a sequencing read (e.g. R1, I1)
 
   -r, --read-structures <READ_STRUCTURES>...
-          The read structures, one per input FASTQ in the same order
+          The read structures, one per input FASTQ in the same order.
+
+          Per-sample read structures (see the `read_structure_<n>` metadata columns) take precedence for each matched sample, and a blank cell falls back to the corresponding `--read-structures` entry.  The unmatched pseudo-sample always uses `--read-structures` for its output extraction.  The number of `read_structure_<n>` columns must equal `--read-structures.len()`.
 
   -b, --output-types <OUTPUT_TYPES>...
           The read structure types to write to their own files (Must be one of T, B, M, or C for template reads, sample barcode reads, molecular barcode reads, or cellular barcode reads).

--- a/README.md
+++ b/README.md
@@ -105,6 +105,46 @@ The expected barcode sequence may contains Ns, which are not counted as mismatch
 of the observed base (e.g. the expected barcode `AAN` will have zero mismatches relative to
 both the observed barcodes `AAA` and `AAN`).
 
+## Per-sample read structures
+
+In addition to the global `--read-structures`, the metadata TSV may include optional columns
+`read_structure_1`, `read_structure_2`, ..., `read_structure_<N>` (where `N` is the number of
+input FASTQs).  When any cell is non-empty for a sample, the per-sample read structures
+replace the global `--read-structures` for that sample — both for matching and for output
+extraction.
+
+Per-sample structures support per-cell fall-back to the global `--read-structures`:
+
+- A blank `read_structure_<i>` cell uses `--read-structures[i-1]` for that sample's input *i*.
+- A row whose `read_structure_<n>` cells are all blank uses `--read-structures` entirely for
+  that sample (equivalent to omitting the columns for that sample only).
+- The unmatched pseudo-sample always uses the global `--read-structures`.
+
+Constraints:
+
+1. The number of `read_structure_<n>` columns must equal `--read-structures.len()`.
+2. The concatenated `B`-segment length must equal the `barcode` column length for every
+   sample (computed from each sample's *effective* read structures, i.e. with fall-backs
+   applied).
+
+Different samples may have different per-input `(T, B, M, C)` segment counts (and hence
+produce different sets of output files).  This supports protocols with sample-dependent
+read structures (e.g. CODEC, where each sample may include a stagger spacer of varying
+length so that the position of the constant ligation base shifts per sample).
+
+During matching, each sample's expected pattern is constructed from its effective read
+structure by filling `B`-segment positions from the `barcode` column and treating
+`M`/`S`/`C` segment positions as `N` wildcards.  All patterns are padded with trailing `N`s
+to a per-input matching window equal to the longest pre-template prefix across samples.
+
+Example metadata TSV (CODEC stagger):
+
+```text
+sample_id  barcode         read_structure_1   read_structure_2
+S1         GATTACAGATTACA  3M7B1S+T           3M7B1S+T
+S2         TTTTTTTTTTTTTT  3M1S7B1S+T         3M1S7B1S+T
+```
+
 ## Outputs
 
 All outputs are generated in the provided `--output` directory.  For each sample plus the
@@ -144,7 +184,9 @@ Options:
           One or more input FASTQ files each corresponding to a sequencing read (e.g. R1, I1)
 
   -r, --read-structures <READ_STRUCTURES>...
-          The read structures, one per input FASTQ in the same order
+          The read structures, one per input FASTQ in the same order.
+
+          Per-sample read structures (see the `read_structure_<n>` metadata columns) take precedence for each matched sample, and a blank cell falls back to the corresponding `--read-structures` entry.  The unmatched pseudo-sample always uses `--read-structures` for its output extraction.  The number of `read_structure_<n>` columns must equal `--read-structures.len()`.
 
   -b, --output-types <OUTPUT_TYPES>...
           The read structure types to write to their own files (Must be one of T, B, M, or C for template reads, sample barcode reads, molecular barcode reads, or cellular barcode reads).

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -76,13 +76,45 @@ impl FromStr for SkipReason {
     }
 }
 
+/// The raw bases and qualities of a single FASTQ record from one input file, retained so the
+/// record can be re-segmented per-sample when per-sample read structures are in use.
+#[derive(PartialEq, Eq, Debug, Clone)]
+struct RawInput {
+    bases: Vec<u8>,
+    quals: Vec<u8>,
+}
+
+/// Error returned by [`ReadSet::resegment`].  The two variants let callers distinguish reads
+/// that were too short to extract every segment (always recoverable by counting them as
+/// `TooFewBases` skips) from genuinely unexpected failures (which should abort the run).
+#[derive(Debug)]
+enum ResegmentError {
+    /// The raw bases were too short to extract one or more segments of the read structure.
+    TooShort(anyhow::Error),
+    /// An unexpected error other than insufficient length.
+    Other(anyhow::Error),
+}
+
+impl ResegmentError {
+    /// Consumes the error and returns the underlying [`anyhow::Error`].
+    fn into_inner(self) -> anyhow::Error {
+        match self {
+            ResegmentError::TooShort(e) | ResegmentError::Other(e) => e,
+        }
+    }
+}
+
 /// One unit of FASTQ records separated into their component read segments.
 #[derive(PartialEq, Debug, Clone)]
 struct ReadSet {
     /// Header of the FASTQ record
     header: Vec<u8>,
-    /// Segments of reads
+    /// Segments of reads (built using the global read structures).
     segments: Vec<FastqSegment>,
+    /// The raw bases / qualities from each input FASTQ, in input order.  Used to rebuild
+    /// segments when a matched sample has its own per-sample read structures.  Empty for the
+    /// no-per-sample-read-structures case (and for skipped reads).
+    raw_per_input: Vec<RawInput>,
     /// The reason the read should be skipped for demultiplexing, or None if it should be
     /// demultiplexed.
     skip_reason: Option<SkipReason>,
@@ -122,17 +154,103 @@ impl ReadSet {
         self.sample_barcode_segments().flat_map(|s| &s.seq).copied().collect()
     }
 
+    /// Returns a fixed-length, per-input prefix slice of the raw bases concatenated across all
+    /// input FASTQs, used to perform per-sample N-padded matching when per-sample read
+    /// structures are in use.  Callers are responsible for ensuring every input has at least
+    /// `prefix_lens[i]` bases — `ReadSetIterator` already gates each input on this length, so
+    /// any read reaching this method is guaranteed long enough.
+    ///
+    /// # Panics
+    ///   - In debug builds, panics if any input has fewer bases than its prefix length.
+    fn matching_window_bases(&self, prefix_lens: &[usize]) -> Vec<u8> {
+        let total: usize = prefix_lens.iter().sum();
+        let mut out = Vec::with_capacity(total);
+        for (raw, &plen) in self.raw_per_input.iter().zip(prefix_lens) {
+            debug_assert!(
+                raw.bases.len() >= plen,
+                "raw bases length {} < matching prefix length {}; ReadSetIterator should have \
+                 gated this read",
+                raw.bases.len(),
+                plen,
+            );
+            out.extend_from_slice(&raw.bases[..plen]);
+        }
+        out
+    }
+
+    /// Consumes this read set and returns a new one with `segments` extracted from
+    /// `raw_per_input` according to the supplied per-input read structures.  `raw_per_input`
+    /// is dropped (no longer needed once segments are built); `header` is moved through.
+    ///
+    /// # Errors
+    ///   - Returns [`ResegmentError::TooShort`] if any segment falls outside the available
+    ///     bases for that input (i.e. the read is shorter than the read structure requires).
+    ///   - Returns [`ResegmentError::Other`] for any other extraction failure.
+    /// # Panics
+    ///   - Will panic if `read_structures.len() != self.raw_per_input.len()`.
+    fn resegment(self, read_structures: &[ReadStructure]) -> Result<Self, ResegmentError> {
+        assert_eq!(
+            read_structures.len(),
+            self.raw_per_input.len(),
+            "resegment requires one read structure per input FASTQ ({} vs {})",
+            read_structures.len(),
+            self.raw_per_input.len(),
+        );
+        let total_segments: usize = read_structures.iter().map(|rs| rs.number_of_segments()).sum();
+        let mut segments = Vec::with_capacity(total_segments);
+        for (raw, rs) in self.raw_per_input.iter().zip(read_structures.iter()) {
+            for seg in rs.iter() {
+                let (s, q) = match seg.extract_bases_and_quals(&raw.bases, &raw.quals) {
+                    Ok(ok) => ok,
+                    Err(e) => {
+                        let is_length_error = matches!(
+                            e,
+                            ReadStructureError::ReadEndsBeforeSegment(_)
+                                | ReadStructureError::ReadEndsAfterSegment(_)
+                        );
+                        let wrapped = anyhow!(
+                            "Error extracting bases (len: {}) for read structure ({}) from \
+                             FASTQ record {}: {}",
+                            raw.bases.len(),
+                            rs,
+                            String::from_utf8_lossy(&self.header),
+                            e,
+                        );
+                        return Err(if is_length_error {
+                            ResegmentError::TooShort(wrapped)
+                        } else {
+                            ResegmentError::Other(wrapped)
+                        });
+                    }
+                };
+                segments.push(FastqSegment {
+                    seq: s.to_vec(),
+                    quals: q.to_vec(),
+                    segment_type: seg.kind,
+                });
+            }
+        }
+        Ok(Self {
+            header: self.header,
+            segments,
+            raw_per_input: Vec::new(),
+            skip_reason: self.skip_reason,
+        })
+    }
+
     /// Combines ``ReadSet`` structs together into a single ``ReadSet``
     fn combine_readsets(readsets: Vec<Self>) -> Self {
+        assert!(!readsets.is_empty(), "Cannot call combine readsets on an empty vec!");
         let total_segments: usize = readsets.iter().map(|s| s.segments.len()).sum();
-        assert!(total_segments > 0, "Cannot call combine readsets on an empty vec!");
 
         let mut readset_iter = readsets.into_iter();
         let mut first = readset_iter.next().expect("Cannot call combine readsets on an empty vec!");
         first.segments.reserve_exact(total_segments - first.segments.len());
+        first.raw_per_input.reserve_exact(readset_iter.len());
 
         for next_readset in readset_iter {
             first.segments.extend(next_readset.segments);
+            first.raw_per_input.extend(next_readset.raw_per_input);
         }
 
         first
@@ -280,6 +398,13 @@ struct ReadSetIterator {
     source: FastqReader<Box<dyn BufRead + Send>>,
     /// Valid reasons for skipping reads, otherwise panic!
     skip_reasons: Vec<SkipReason>,
+    /// If true, the raw bases and qualities for each record will be retained on the resulting
+    /// `ReadSet` so that records can be re-segmented per-sample later.
+    keep_raw: bool,
+    /// The minimum number of bases required to extract every segment of `read_structure`.
+    /// Pre-computed once at construction time and used to short-circuit reads that are too
+    /// short.
+    min_len: usize,
 }
 
 impl Iterator for ReadSetIterator {
@@ -287,20 +412,17 @@ impl Iterator for ReadSetIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(rec) = self.source.next() {
-            let mut segments = Vec::with_capacity(self.read_structure.number_of_segments());
             let next_fq_rec = rec.expect("Unexpected error parsing FASTQs");
             let read_name = next_fq_rec.head();
             let bases = next_fq_rec.seq();
             let quals = next_fq_rec.qual();
 
-            // Check that we have enough bases for this segment. For variable length segments,
-            // we must have at least one base.
-            let min_len = self.read_structure.iter().map(|s| s.length().unwrap_or(1)).sum();
-            if bases.len() < min_len {
+            if bases.len() < self.min_len {
                 if self.skip_reasons.contains(&SkipReason::TooFewBases) {
                     return Some(ReadSet {
                         header: read_name.to_vec(),
                         segments: vec![],
+                        raw_per_input: vec![],
                         skip_reason: Some(SkipReason::TooFewBases),
                     });
                 }
@@ -308,13 +430,25 @@ impl Iterator for ReadSetIterator {
                     "Read {} had too few bases to demux {} vs. {} needed in read structure {}.",
                     String::from_utf8(read_name.to_vec()).unwrap(),
                     bases.len(),
-                    min_len,
+                    self.min_len,
                     self.read_structure
                 );
             }
 
+            // In keep_raw mode the caller will re-segment per-sample (or per-globals for
+            // unmatched) downstream, so skip the up-front extraction and just retain the raw
+            // bases/quals.
+            if self.keep_raw {
+                return Some(ReadSet {
+                    header: read_name.to_vec(),
+                    segments: vec![],
+                    raw_per_input: vec![RawInput { bases: bases.to_vec(), quals: quals.to_vec() }],
+                    skip_reason: None,
+                });
+            }
+
+            let mut segments = Vec::with_capacity(self.read_structure.number_of_segments());
             for (read_segment_index, read_segment) in self.read_structure.iter().enumerate() {
-                // Extract the bases and qualities for this segment
                 let (seq, quals) =
                     read_segment.extract_bases_and_quals(bases, quals).unwrap_or_else(|e| {
                         panic!(
@@ -328,14 +462,18 @@ impl Iterator for ReadSetIterator {
                             e
                         )
                     });
-                // Add a new FastqSegment
                 segments.push(FastqSegment {
                     seq: seq.to_vec(),
                     quals: quals.to_vec(),
                     segment_type: read_segment.kind,
                 });
             }
-            Some(ReadSet { header: read_name.to_vec(), segments, skip_reason: None })
+            Some(ReadSet {
+                header: read_name.to_vec(),
+                segments,
+                raw_per_input: vec![],
+                skip_reason: None,
+            })
         } else {
             None
         }
@@ -344,13 +482,18 @@ impl Iterator for ReadSetIterator {
 
 impl ReadSetIterator {
     /// Instantiates a new iterator over the read sets for a set of FASTQs with defined read
-    /// structures
+    /// structures.  When `keep_raw` is true, segment extraction is deferred — the resulting
+    /// `ReadSet`s carry only the raw bases/quals per input so that callers can re-segment
+    /// per-sample (or per-globals) downstream.  `min_len` is the minimum number of bases a
+    /// record must have for this iterator to yield it (or skip it as `TooFewBases`).
     pub fn new(
         read_structure: ReadStructure,
         source: FastqReader<Box<dyn BufRead + Send>>,
         skip_reasons: Vec<SkipReason>,
+        keep_raw: bool,
+        min_len: usize,
     ) -> Self {
-        Self { read_structure, source, skip_reasons }
+        Self { read_structure, source, skip_reasons, keep_raw, min_len }
     }
 }
 
@@ -562,6 +705,46 @@ impl DemuxMetric {
 /// of the observed base (e.g. the expected barcode `AAN` will have zero mismatches relative to
 /// both the observed barcodes `AAA` and `AAN`).
 ///
+/// ## Per-sample read structures
+///
+/// In addition to the global `--read-structures`, the metadata TSV may include optional columns
+/// `read_structure_1`, `read_structure_2`, ..., `read_structure_<N>` (where `N` is the number of
+/// input FASTQs).  When any cell is non-empty for a sample, the per-sample read structures
+/// replace the global `--read-structures` for that sample — both for matching and for output
+/// extraction.
+///
+/// Per-sample structures support per-cell fall-back to the global `--read-structures`:
+///
+/// - A blank `read_structure_<i>` cell uses `--read-structures[i-1]` for that sample's input *i*.
+/// - A row whose `read_structure_<n>` cells are all blank uses `--read-structures` entirely for
+///   that sample (equivalent to omitting the columns for that sample only).
+/// - The unmatched pseudo-sample always uses the global `--read-structures`.
+///
+/// Constraints:
+///
+/// 1. The number of `read_structure_<n>` columns must equal `--read-structures.len()`.
+/// 2. The concatenated `B`-segment length must equal the `barcode` column length for every
+///    sample (computed from each sample's *effective* read structures, i.e. with fall-backs
+///    applied).
+///
+/// Different samples may have different per-input `(T, B, M, C)` segment counts (and hence
+/// produce different sets of output files).  This supports protocols with sample-dependent
+/// read structures (e.g. CODEC, where each sample may include a stagger spacer of varying
+/// length so that the position of the constant ligation base shifts per sample).
+///
+/// During matching, each sample's expected pattern is constructed from its effective read
+/// structure by filling `B`-segment positions from the `barcode` column and treating
+/// `M`/`S`/`C` segment positions as `N` wildcards.  All patterns are padded with trailing `N`s
+/// to a per-input matching window equal to the longest pre-template prefix across samples.
+///
+/// Example metadata TSV (CODEC stagger):
+///
+/// ```text
+/// sample_id  barcode         read_structure_1   read_structure_2
+/// S1         GATTACAGATTACA  3M7B1S+T           3M7B1S+T
+/// S2         TTTTTTTTTTTTTT  3M1S7B1S+T         3M1S7B1S+T
+/// ```
+///
 /// ## Outputs
 ///
 /// All outputs are generated in the provided `--output` directory.  For each sample plus the
@@ -603,6 +786,12 @@ pub(crate) struct Demux {
     inputs: Vec<PathBuf>,
 
     /// The read structures, one per input FASTQ in the same order.
+    ///
+    /// Per-sample read structures (see the `read_structure_<n>` metadata columns) take
+    /// precedence for each matched sample, and a blank cell falls back to the corresponding
+    /// `--read-structures` entry.  The unmatched pseudo-sample always uses
+    /// `--read-structures` for its output extraction.  The number of `read_structure_<n>`
+    /// columns must equal `--read-structures.len()`.
     #[clap(long, short = 'r' , required = true, num_args = 1..)]
     read_structures: Vec<ReadStructure>,
 
@@ -713,7 +902,9 @@ impl Demux {
     }
 
     /// Creates one writer per sample per read segment in the provided read structures for
-    /// requested output type.
+    /// requested output type.  Each sample's writers are created from its per-sample read
+    /// structures when present; otherwise the global `read_structures` are used.  The
+    /// unmatched pseudo-sample always uses the global `read_structures`.
     /// # Errors:
     ///     - Will error if opening the output fails for any reason.
     fn create_writers(
@@ -725,14 +916,15 @@ impl Demux {
     ) -> Result<Vec<SampleWriters<BufWriter<File>>>> {
         let mut samples_writers = Vec::with_capacity(sample_group.samples.len());
         for sample in &sample_group.samples {
+            let rs = sample.read_structures.as_deref().unwrap_or(read_structures);
             samples_writers.push(Self::create_sample_writers(
-                read_structures,
+                rs,
                 &sample.sample_id,
                 output_types,
                 output_dir,
             )?);
         }
-        // Add the unmatched 'sample'
+        // Add the unmatched 'sample' using the global read structures.
         samples_writers.push(Self::create_sample_writers(
             read_structures,
             unmatched_prefix,
@@ -881,7 +1073,7 @@ impl Command for Demux {
     fn execute(&self) -> Result<()> {
         let (fq_readers, output_segment_types) = self.validate_and_prepare_inputs()?;
 
-        let sample_group = SampleGroup::from_file(&self.sample_metadata)?;
+        let sample_group = SampleGroup::from_file(&self.sample_metadata, &self.read_structures)?;
         info!(
             "{} samples loaded from file {:?}",
             sample_group.samples.len(),
@@ -909,7 +1101,6 @@ impl Command for Demux {
         let unmatched_index = sample_writers.len() - 1;
         info!("Created sample and {} writers.", self.unmatched_prefix);
 
-        // Create the metrics as a Vec that is index sync'd with the sample group
         let mut sample_metrics = sample_group
             .samples
             .iter()
@@ -917,19 +1108,56 @@ impl Command for Demux {
             .collect_vec();
         let mut unmatched_metric = DemuxMetric::new(self.unmatched_prefix.as_str(), ".");
 
-        // Setup the barcode matcher - the primary return from here is the index of the samp
-        let mut barcode_matcher = BarcodeMatcher::new(
-            &sample_group.samples,
-            u8::try_from(self.max_mismatches)?,
-            u8::try_from(self.min_mismatch_delta)?,
-            true,
-        );
+        let per_sample_rs = sample_group.has_per_sample_read_structures();
+        let prefix_lens = if per_sample_rs {
+            sample_group.matching_prefix_lens(&self.read_structures)?
+        } else {
+            Vec::new()
+        };
+        let matching_patterns = if per_sample_rs {
+            sample_group.build_matching_patterns(&self.read_structures, &prefix_lens)?
+        } else {
+            Vec::new()
+        };
 
+        let mut barcode_matcher = if per_sample_rs {
+            BarcodeMatcher::with_patterns(
+                &sample_group.samples,
+                matching_patterns,
+                u8::try_from(self.max_mismatches)?,
+                u8::try_from(self.min_mismatch_delta)?,
+                true,
+            )
+        } else {
+            BarcodeMatcher::new(
+                &sample_group.samples,
+                u8::try_from(self.max_mismatches)?,
+                u8::try_from(self.min_mismatch_delta)?,
+                true,
+            )
+        };
+
+        // In per-sample mode the iterator gates on the per-input matching-window length
+        // (prefix_lens[i]); the global read structure's full min_len would over-reject reads
+        // that satisfy a sample's shorter structure.  Re-segmentation downstream re-checks
+        // length against the matched sample's structure.
         let mut fq_iterators = fq_sources
             .zip(self.read_structures.clone())
-            .map(|(source, read_structure)| {
-                ReadSetIterator::new(read_structure, source, self.skip_reasons.clone())
-                    .read_ahead(1000, 1000)
+            .enumerate()
+            .map(|(i, (source, read_structure))| {
+                let min_len = if per_sample_rs {
+                    prefix_lens[i]
+                } else {
+                    read_structure.iter().map(|s| s.length().unwrap_or(1)).sum()
+                };
+                ReadSetIterator::new(
+                    read_structure,
+                    source,
+                    self.skip_reasons.clone(),
+                    per_sample_rs,
+                    min_len,
+                )
+                .read_ahead(1000, 1000)
             })
             .collect::<Vec<_>>();
 
@@ -941,6 +1169,7 @@ impl Command for Demux {
             .count_formatter(CountFormatterKind::Comma)
             .level(log::Level::Info)
             .build();
+        let allow_too_few = self.skip_reasons.contains(&SkipReason::TooFewBases);
         let mut skip_reasons: HashMap<SkipReason, usize> = HashMap::new();
         loop {
             let mut next_read_sets = Vec::with_capacity(fq_iterators.len());
@@ -949,8 +1178,6 @@ impl Command for Demux {
                     next_read_sets.push(rec);
                 }
             }
-            // Either skip the reason if any FASTQ record could not be destructured, or break the
-            // loop if no read were found indicating EOF.
             if let Some(reason) = next_read_sets.iter().find_map(|read_set| read_set.skip_reason) {
                 let previous = skip_reasons.get(&reason).unwrap_or(&0);
                 skip_reasons.insert(reason, 1 + previous);
@@ -965,10 +1192,48 @@ impl Command for Demux {
                 next_read_sets
             );
             let read_set = ReadSet::combine_readsets(next_read_sets);
-            if let Some(barcode_match) = barcode_matcher.assign(&read_set.sample_barcode_sequence())
-            {
-                sample_writers[barcode_match.best_match].write(&read_set)?;
-                sample_metrics[barcode_match.best_match].templates += 1;
+            let observed: Vec<u8> = if per_sample_rs {
+                read_set.matching_window_bases(&prefix_lens)
+            } else {
+                read_set.sample_barcode_sequence()
+            };
+            if let Some(barcode_match) = barcode_matcher.assign(&observed) {
+                let matched_idx = barcode_match.best_match;
+                if per_sample_rs {
+                    let rs_for_sample = sample_group.samples[matched_idx]
+                        .read_structures
+                        .as_deref()
+                        .unwrap_or(&self.read_structures);
+                    match read_set.resegment(rs_for_sample) {
+                        Ok(resegmented) => {
+                            sample_writers[matched_idx].write(&resegmented)?;
+                            sample_metrics[matched_idx].templates += 1;
+                        }
+                        Err(ResegmentError::TooShort(_)) if allow_too_few => {
+                            *skip_reasons.entry(SkipReason::TooFewBases).or_insert(0) += 1;
+                        }
+                        Err(e) => return Err(e.into_inner()),
+                    }
+                } else {
+                    sample_writers[matched_idx].write(&read_set)?;
+                    sample_metrics[matched_idx].templates += 1;
+                }
+            } else if per_sample_rs {
+                // Iterator gating in per-sample mode is loosened to the matching prefix length,
+                // so a read can satisfy the prefix gate while being too short for the global
+                // read structure.  Treat such reads as `TooFewBases` skips on the unmatched
+                // path regardless of `--skip-reasons` — legacy mode would have rejected them at
+                // the iterator and per-sample mode opts the user into heterogeneous lengths.
+                match read_set.resegment(&self.read_structures) {
+                    Ok(resegmented) => {
+                        sample_writers[unmatched_index].write(&resegmented)?;
+                        unmatched_metric.templates += 1;
+                    }
+                    Err(ResegmentError::TooShort(_)) => {
+                        *skip_reasons.entry(SkipReason::TooFewBases).or_insert(0) += 1;
+                    }
+                    Err(ResegmentError::Other(e)) => return Err(e),
+                }
             } else {
                 sample_writers[unmatched_index].write(&read_set)?;
                 unmatched_metric.templates += 1;
@@ -1093,7 +1358,12 @@ mod tests {
     }
 
     fn read_set(segments: Vec<FastqSegment>) -> ReadSet {
-        ReadSet { header: "NOT_IMPORTANT".as_bytes().to_owned(), segments, skip_reason: None }
+        ReadSet {
+            header: "NOT_IMPORTANT".as_bytes().to_owned(),
+            segments,
+            raw_per_input: vec![],
+            skip_reason: None,
+        }
     }
 
     // ############################################################################################
@@ -2321,5 +2591,276 @@ mod tests {
     #[should_panic(expected = "Cannot call combine readsets on an empty vec!")]
     fn test_combine_readsets_fails_on_empty_vector() {
         let _result = ReadSet::combine_readsets(Vec::new());
+    }
+
+    // ############################################################################################
+    // Tests for per-sample read structures (CODEC-style stagger).
+    // ############################################################################################
+
+    /// Writes a per-sample-read-structures metadata TSV with columns:
+    ///     sample_id, barcode, read_structure_1, ..., read_structure_<n>
+    /// `samples` is a slice of (sample_id, barcode, [read_structure_per_input...]).
+    fn metadata_file_with_rs(tmpdir: &TempDir, samples: &[(&str, &str, &[&str])]) -> PathBuf {
+        let n_inputs = samples[0].2.len();
+        let mut header = String::from("sample_id\tbarcode");
+        for i in 1..=n_inputs {
+            header.push('\t');
+            header.push_str(&format!("read_structure_{i}"));
+        }
+        let mut lines = vec![header];
+        for (sid, bc, structs) in samples {
+            assert_eq!(structs.len(), n_inputs);
+            let mut line = format!("{sid}\t{bc}");
+            for s in structs.iter() {
+                line.push('\t');
+                line.push_str(s);
+            }
+            lines.push(line);
+        }
+        let path = tmpdir.path().join("metadata.tsv");
+        Io::default().write_lines(&path, lines).unwrap();
+        path
+    }
+
+    /// End-to-end CODEC stagger test:
+    ///   Sample S1 (no stagger):  3M7B1S+T   barcode = GATTACA
+    ///   Sample S2 (1bp stagger): 3M1S7B1S+T barcode = TTTTTTT
+    /// One paired-end read per sample, each with a 50bp template after the constant `T`
+    /// stagger anchor.  Verifies that:
+    ///   1. Each read is assigned to the correct sample.
+    ///   2. The output template starts at the right position (no template haircut for the
+    ///      shorter-stagger sample).
+    ///   3. The UMI (M) and sample-barcode (B) outputs reflect the per-sample structure.
+    #[test]
+    fn test_demux_codec_per_sample_read_structures_paired_end() {
+        let tmp = TempDir::new().unwrap();
+
+        // The global `--read-structures` is provided but should not be used for matched
+        // samples (they have their own).  Its per-input segment signature can differ from the
+        // per-sample structures; the unmatched output uses globals independently.
+        let read_structures =
+            vec![ReadStructure::from_str("+T").unwrap(), ReadStructure::from_str("+T").unwrap()];
+
+        let s1_template_r1 = "A".repeat(50);
+        let s1_template_r2 = "C".repeat(50);
+        // Sample 1, no stagger: NNN GATTACA T <template>
+        let s1_r1 = format!("AAA{}T{}", "GATTACA", s1_template_r1);
+        let s1_r2 = format!("CCC{}T{}", "GATTACA", s1_template_r2);
+
+        let s2_template_r1 = "G".repeat(50);
+        let s2_template_r2 = "T".repeat(50);
+        // Sample 2, 1bp stagger: NNN A TTTTTTT T <template>
+        let s2_r1 = format!("GGGA{}T{}", "TTTTTTT", s2_template_r1);
+        let s2_r2 = format!("TTTA{}T{}", "TTTTTTT", s2_template_r2);
+
+        let r1_file = fastq_file(&tmp, "r1", "ex", &[s1_r1.as_str(), s2_r1.as_str()]);
+        let r2_file = fastq_file(&tmp, "r2", "ex", &[s1_r2.as_str(), s2_r2.as_str()]);
+
+        let sample_metadata = metadata_file_with_rs(
+            &tmp,
+            &[
+                ("S1", "GATTACAGATTACA", &["3M7B1S+T", "3M7B1S+T"]),
+                ("S2", "TTTTTTTTTTTTTT", &["3M1S7B1S+T", "3M1S7B1S+T"]),
+            ],
+        );
+
+        let output_dir = tmp.path().join("output");
+        let demux_inputs = Demux {
+            inputs: vec![r1_file, r2_file],
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T', 'B', 'M'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+        };
+        demux_inputs.execute().unwrap();
+
+        // Sample 1: per-sample RS = 3M7B1S+T for both inputs.  Expect 50bp template per read,
+        // 7bp barcode per read, 3bp UMI per read.
+        let s1_r1_reads = read_fastq(&output_dir.join("S1.R1.fq.gz"));
+        let s1_r2_reads = read_fastq(&output_dir.join("S1.R2.fq.gz"));
+        let s1_b1_reads = read_fastq(&output_dir.join("S1.I1.fq.gz"));
+        let s1_b2_reads = read_fastq(&output_dir.join("S1.I2.fq.gz"));
+        let s1_m1_reads = read_fastq(&output_dir.join("S1.U1.fq.gz"));
+        let s1_m2_reads = read_fastq(&output_dir.join("S1.U2.fq.gz"));
+
+        assert_eq!(s1_r1_reads.len(), 1, "S1 R1 should have one read");
+        assert_eq!(s1_r1_reads[0].seq, s1_template_r1.as_bytes());
+        assert_eq!(s1_r2_reads[0].seq, s1_template_r2.as_bytes());
+        assert_eq!(s1_b1_reads[0].seq, b"GATTACA");
+        assert_eq!(s1_b2_reads[0].seq, b"GATTACA");
+        assert_eq!(s1_m1_reads[0].seq, b"AAA");
+        assert_eq!(s1_m2_reads[0].seq, b"CCC");
+
+        // Sample 2: per-sample RS = 3M1S7B1S+T for both inputs.
+        let s2_r1_reads = read_fastq(&output_dir.join("S2.R1.fq.gz"));
+        let s2_r2_reads = read_fastq(&output_dir.join("S2.R2.fq.gz"));
+        let s2_b1_reads = read_fastq(&output_dir.join("S2.I1.fq.gz"));
+        let s2_m1_reads = read_fastq(&output_dir.join("S2.U1.fq.gz"));
+
+        assert_eq!(s2_r1_reads.len(), 1, "S2 R1 should have one read");
+        assert_eq!(s2_r1_reads[0].seq, s2_template_r1.as_bytes());
+        assert_eq!(s2_r2_reads[0].seq, s2_template_r2.as_bytes());
+        assert_eq!(s2_b1_reads[0].seq, b"TTTTTTT");
+        assert_eq!(s2_m1_reads[0].seq, b"GGG");
+
+        // The unmatched outputs (using globals `+T +T`) only have R*.fq.gz files.  All reads
+        // matched, so they should be empty.
+        let unmatched_r1 = read_fastq(&output_dir.join("unmatched.R1.fq.gz"));
+        let unmatched_r2 = read_fastq(&output_dir.join("unmatched.R2.fq.gz"));
+        assert!(unmatched_r1.is_empty(), "unmatched R1 should be empty");
+        assert!(unmatched_r2.is_empty(), "unmatched R2 should be empty");
+    }
+
+    /// Ensures that when no per-sample read structures are present, behaviour is identical
+    /// to the legacy code path (uses global `--read-structures`).
+    #[test]
+    fn test_demux_falls_back_to_global_read_structures() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("17B100T").unwrap()];
+        let s1_barcode = "AAAAAAAAGATTACAGA";
+        let sample_metadata = metadata_file(
+            &tmp,
+            &[s1_barcode, "CCCCCCCCGATTACAGA", "GGGGGGGGGATTACAGA", "GGGGGGTTGATTACAGA"],
+        );
+        let input_files =
+            vec![fastq_file(&tmp, "ex", "ex", &[&(s1_barcode.to_owned() + &"A".repeat(100))])];
+
+        let output_dir = tmp.path().join("output");
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+        };
+        demux_inputs.execute().unwrap();
+
+        let fq_reads = read_fastq(&output_dir.join("Sample0000.R1.fq.gz"));
+        assert_eq!(fq_reads.len(), 1);
+        assert_eq!(fq_reads[0].seq, "A".repeat(100).as_bytes());
+    }
+
+    /// Errors when per-sample `read_structure_<n>` columns disagree with the number of
+    /// `--read-structures` entries.
+    #[test]
+    fn test_demux_errors_when_per_sample_input_count_mismatches_global() {
+        let tmp = TempDir::new().unwrap();
+        let r1_file =
+            fastq_file(&tmp, "r1", "ex", &[format!("AAAGATTACAT{}", "A".repeat(50)).as_str()]);
+        // Metadata declares 1 read_structure column, but globals declare 2 inputs.
+        let sample_metadata = metadata_file_with_rs(&tmp, &[("S1", "GATTACA", &["3M7B1S+T"])]);
+
+        let demux_inputs = Demux {
+            inputs: vec![r1_file.clone(), r1_file],
+            read_structures: vec![
+                ReadStructure::from_str("3M7B+T").unwrap(),
+                ReadStructure::from_str("3M7B+T").unwrap(),
+            ],
+            sample_metadata,
+            output_types: vec!['T'],
+            output: tmp.path().join("output"),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+        };
+        let err = demux_inputs.execute().unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("`read_structure_<n>` column(s)") && msg.contains("--read-structures"),
+            "got: {msg}",
+        );
+    }
+
+    /// Per-sample read structures may have a different `(T, B, M, C)` segment signature than
+    /// the global `--read-structures` — different samples may produce different sets of
+    /// output files, and the unmatched output uses the global structures independently.
+    #[test]
+    fn test_demux_per_sample_signature_may_differ_from_global() {
+        let tmp = TempDir::new().unwrap();
+        // Per-sample has (T=1, B=1, M=1, C=0); global has (T=1, B=1, M=0, C=0) — M counts differ.
+        let r1 = format!("AAAGATTACAT{}", "A".repeat(50));
+        let r1_file = fastq_file(&tmp, "r1", "ex", &[r1.as_str()]);
+        let sample_metadata = metadata_file_with_rs(&tmp, &[("S1", "GATTACA", &["3M7B1S+T"])]);
+
+        let demux_inputs = Demux {
+            inputs: vec![r1_file],
+            read_structures: vec![ReadStructure::from_str("7B+T").unwrap()],
+            sample_metadata,
+            output_types: vec!['T', 'M'],
+            output: tmp.path().join("output").clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+        };
+        let output_dir = demux_inputs.output.clone();
+        demux_inputs.execute().unwrap();
+        // S1 produces R1 + U1 (matches per-sample 3M7B1S+T → 1T, 1M).
+        let s1_r1 = read_fastq(&output_dir.join("S1.R1.fq.gz"));
+        let s1_u1 = read_fastq(&output_dir.join("S1.U1.fq.gz"));
+        assert_eq!(s1_r1.len(), 1);
+        assert_eq!(s1_u1.len(), 1);
+        assert_eq!(s1_u1[0].seq, b"AAA");
+        // Globals (7B+T) have no M segment, so unmatched only writes R1; the file may not even
+        // exist if no unmatched reads occurred.  In this test, the read matches S1, so there
+        // are no unmatched records.
+    }
+
+    /// Regression: in per-sample mode the iterator gates on the per-sample matching prefix,
+    /// which can be shorter than the global `--read-structures` minimum.  A read that satisfies
+    /// the prefix gate but does not match any sample reaches the unmatched branch where
+    /// resegmentation against the global structure would fail on length.  The run must not
+    /// abort; the read must be counted as a `TooFewBases` skip independently of `--skip-reasons`.
+    #[test]
+    fn test_demux_per_sample_unmatched_short_read_does_not_abort() {
+        let tmp = TempDir::new().unwrap();
+        // Global is 8B+T per input (min_len 9); sample S1 has 3B+T per input (prefix 3).
+        let read_structures = vec![
+            ReadStructure::from_str("8B+T").unwrap(),
+            ReadStructure::from_str("8B+T").unwrap(),
+        ];
+        let sample_metadata = metadata_file_with_rs(&tmp, &[("S1", "AAAAAA", &["3B+T", "3B+T"])]);
+        // 3-byte reads per input that don't match S1's "AAA"+"AAA" matching pattern.
+        let r1_file = fastq_file(&tmp, "r1", "ex", &["TTT"]);
+        let r2_file = fastq_file(&tmp, "r2", "ex", &["TTT"]);
+
+        let output_dir = tmp.path().join("output");
+        let demux_inputs = Demux {
+            inputs: vec![r1_file, r2_file],
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T', 'B'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            // Critically NOT requesting too-few-bases skip; legacy resegment path would abort.
+            skip_reasons: vec![],
+        };
+        demux_inputs.execute().unwrap();
+
+        let metrics_path = output_dir.join("demux-metrics.txt");
+        let metrics: Vec<DemuxMetric> = DelimFile::default().read_tsv(&metrics_path).unwrap();
+        let demuxed: usize = metrics.iter().map(|m| m.templates).sum();
+        assert_eq!(demuxed, 0, "no reads should be demuxed; the unmatched read is too short");
     }
 }

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -11,6 +11,7 @@ use log::info;
 use pooled_writer::{Pool, PoolBuilder, PooledWriter, bgzf::BgzfCompressor};
 use proglog::{CountFormatterKind, ProgLogBuilder};
 use read_structure::ReadStructure;
+use read_structure::ReadStructureError;
 use read_structure::SegmentType;
 use seq_io::fastq::Reader as FastqReader;
 use seq_io::fastq::Record;
@@ -77,13 +78,45 @@ impl FromStr for SkipReason {
     }
 }
 
+/// The raw bases and qualities of a single FASTQ record from one input file, retained so the
+/// record can be re-segmented per-sample when per-sample read structures are in use.
+#[derive(PartialEq, Eq, Debug, Clone)]
+struct RawInput {
+    bases: Vec<u8>,
+    quals: Vec<u8>,
+}
+
+/// Error returned by [`ReadSet::resegment`].  The two variants let callers distinguish reads
+/// that were too short to extract every segment (always recoverable by counting them as
+/// `TooFewBases` skips) from genuinely unexpected failures (which should abort the run).
+#[derive(Debug)]
+enum ResegmentError {
+    /// The raw bases were too short to extract one or more segments of the read structure.
+    TooShort(anyhow::Error),
+    /// An unexpected error other than insufficient length.
+    Other(anyhow::Error),
+}
+
+impl ResegmentError {
+    /// Consumes the error and returns the underlying [`anyhow::Error`].
+    fn into_inner(self) -> anyhow::Error {
+        match self {
+            ResegmentError::TooShort(e) | ResegmentError::Other(e) => e,
+        }
+    }
+}
+
 /// One unit of FASTQ records separated into their component read segments.
 #[derive(PartialEq, Debug, Clone)]
 struct ReadSet {
     /// Header of the FASTQ record
     header: Vec<u8>,
-    /// Segments of reads
+    /// Segments of reads (built using the global read structures).
     segments: Vec<FastqSegment>,
+    /// The raw bases / qualities from each input FASTQ, in input order.  Used to rebuild
+    /// segments when a matched sample has its own per-sample read structures.  Empty for the
+    /// no-per-sample-read-structures case (and for skipped reads).
+    raw_per_input: Vec<RawInput>,
     /// The reason the read should be skipped for demultiplexing, or None if it should be
     /// demultiplexed.
     skip_reason: Option<SkipReason>,
@@ -123,17 +156,106 @@ impl ReadSet {
         self.sample_barcode_segments().flat_map(|s| &s.seq).copied().collect()
     }
 
+    /// Returns a fixed-length, per-input prefix slice of the raw bases concatenated across all
+    /// input FASTQs, used to perform per-sample N-padded matching when per-sample read
+    /// structures are in use.  Callers are responsible for ensuring every input has at least
+    /// `prefix_lens[i]` bases — `ReadSetIterator` already gates each input on this length, so
+    /// any read reaching this method is guaranteed long enough.
+    ///
+    /// # Panics
+    ///   - In debug builds, panics if any input has fewer bases than its prefix length.
+    fn matching_window_bases(&self, prefix_lens: &[usize]) -> Vec<u8> {
+        let total: usize = prefix_lens.iter().sum();
+        let mut out = Vec::with_capacity(total);
+        for (raw, &plen) in self.raw_per_input.iter().zip(prefix_lens) {
+            debug_assert!(
+                raw.bases.len() >= plen,
+                "raw bases length {} < matching prefix length {}; ReadSetIterator should have \
+                 gated this read",
+                raw.bases.len(),
+                plen,
+            );
+            out.extend_from_slice(&raw.bases[..plen]);
+        }
+        out
+    }
+
+    /// Consumes this read set and returns a new one with `segments` extracted from
+    /// `raw_per_input` according to the supplied per-input read structures.  `raw_per_input`
+    /// is dropped (no longer needed once segments are built); `header` is moved through.
+    ///
+    /// # Errors
+    ///   - Returns [`ResegmentError::TooShort`] if any segment falls outside the available
+    ///     bases for that input (i.e. the read is shorter than the read structure requires).
+    ///   - Returns [`ResegmentError::Other`] for any other extraction failure.
+    /// # Panics
+    ///   - Will panic if `read_structures.len() != self.raw_per_input.len()`.
+    fn resegment(self, read_structures: &[ReadStructure]) -> Result<Self, ResegmentError> {
+        assert_eq!(
+            read_structures.len(),
+            self.raw_per_input.len(),
+            "resegment requires one read structure per input FASTQ ({} vs {})",
+            read_structures.len(),
+            self.raw_per_input.len(),
+        );
+        let total_segments: usize = read_structures.iter().map(|rs| rs.number_of_segments()).sum();
+        let mut segments = Vec::with_capacity(total_segments);
+        for (source_index, (raw, rs)) in
+            self.raw_per_input.iter().zip(read_structures.iter()).enumerate()
+        {
+            for seg in rs.iter() {
+                let (s, q) = match seg.extract_bases_and_quals(&raw.bases, &raw.quals) {
+                    Ok(ok) => ok,
+                    Err(e) => {
+                        let is_length_error = matches!(
+                            e,
+                            ReadStructureError::ReadEndsBeforeSegment(_)
+                                | ReadStructureError::ReadEndsAfterSegment(_)
+                        );
+                        let wrapped = anyhow!(
+                            "Error extracting bases (len: {}) for read structure ({}) from \
+                             FASTQ record {}: {}",
+                            raw.bases.len(),
+                            rs,
+                            String::from_utf8_lossy(&self.header),
+                            e,
+                        );
+                        return Err(if is_length_error {
+                            ResegmentError::TooShort(wrapped)
+                        } else {
+                            ResegmentError::Other(wrapped)
+                        });
+                    }
+                };
+                segments.push(FastqSegment {
+                    seq: s.to_vec(),
+                    quals: q.to_vec(),
+                    segment_type: seg.kind,
+                    source_index,
+                });
+            }
+        }
+        Ok(Self {
+            header: self.header,
+            segments,
+            raw_per_input: Vec::new(),
+            skip_reason: self.skip_reason,
+        })
+    }
+
     /// Combines ``ReadSet`` structs together into a single ``ReadSet``
     fn combine_readsets(readsets: Vec<Self>) -> Self {
+        assert!(!readsets.is_empty(), "Cannot call combine readsets on an empty vec!");
         let total_segments: usize = readsets.iter().map(|s| s.segments.len()).sum();
-        assert!(total_segments > 0, "Cannot call combine readsets on an empty vec!");
 
         let mut readset_iter = readsets.into_iter();
         let mut first = readset_iter.next().expect("Cannot call combine readsets on an empty vec!");
         first.segments.reserve_exact(total_segments - first.segments.len());
+        first.raw_per_input.reserve_exact(readset_iter.len());
 
         for next_readset in readset_iter {
             first.segments.extend(next_readset.segments);
+            first.raw_per_input.extend(next_readset.raw_per_input);
         }
 
         first
@@ -319,6 +441,13 @@ struct ReadSetIterator {
     skip_reasons: Vec<SkipReason>,
     /// The index of this FASTQ source (0-based), used for tracking original reads.
     source_index: usize,
+    /// If true, the raw bases and qualities for each record will be retained on the resulting
+    /// `ReadSet` so that records can be re-segmented per-sample later.
+    keep_raw: bool,
+    /// The minimum number of bases required to extract every segment of `read_structure`.
+    /// Pre-computed once at construction time and used to short-circuit reads that are too
+    /// short.
+    min_len: usize,
 }
 
 impl Iterator for ReadSetIterator {
@@ -326,20 +455,17 @@ impl Iterator for ReadSetIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(rec) = self.source.next() {
-            let mut segments = Vec::with_capacity(self.read_structure.number_of_segments());
             let next_fq_rec = rec.expect("Unexpected error parsing FASTQs");
             let read_name = next_fq_rec.head();
             let bases = next_fq_rec.seq();
             let quals = next_fq_rec.qual();
 
-            // Check that we have enough bases for this segment. For variable length segments,
-            // we must have at least one base.
-            let min_len = self.read_structure.iter().map(|s| s.length().unwrap_or(1)).sum();
-            if bases.len() < min_len {
+            if bases.len() < self.min_len {
                 if self.skip_reasons.contains(&SkipReason::TooFewBases) {
                     return Some(ReadSet {
                         header: read_name.to_vec(),
                         segments: vec![],
+                        raw_per_input: vec![],
                         skip_reason: Some(SkipReason::TooFewBases),
                     });
                 }
@@ -347,13 +473,25 @@ impl Iterator for ReadSetIterator {
                     "Read {} had too few bases to demux {} vs. {} needed in read structure {}.",
                     String::from_utf8(read_name.to_vec()).unwrap(),
                     bases.len(),
-                    min_len,
+                    self.min_len,
                     self.read_structure
                 );
             }
 
+            // In keep_raw mode the caller will re-segment per-sample (or per-globals for
+            // unmatched) downstream, so skip the up-front extraction and just retain the raw
+            // bases/quals.
+            if self.keep_raw {
+                return Some(ReadSet {
+                    header: read_name.to_vec(),
+                    segments: vec![],
+                    raw_per_input: vec![RawInput { bases: bases.to_vec(), quals: quals.to_vec() }],
+                    skip_reason: None,
+                });
+            }
+
+            let mut segments = Vec::with_capacity(self.read_structure.number_of_segments());
             for (read_segment_index, read_segment) in self.read_structure.iter().enumerate() {
-                // Extract the bases and qualities for this segment
                 let (seq, quals) =
                     read_segment.extract_bases_and_quals(bases, quals).unwrap_or_else(|e| {
                         panic!(
@@ -367,7 +505,6 @@ impl Iterator for ReadSetIterator {
                             e
                         )
                     });
-                // Add a new FastqSegment
                 segments.push(FastqSegment {
                     seq: seq.to_vec(),
                     quals: quals.to_vec(),
@@ -375,7 +512,12 @@ impl Iterator for ReadSetIterator {
                     source_index: self.source_index,
                 });
             }
-            Some(ReadSet { header: read_name.to_vec(), segments, skip_reason: None })
+            Some(ReadSet {
+                header: read_name.to_vec(),
+                segments,
+                raw_per_input: vec![],
+                skip_reason: None,
+            })
         } else {
             None
         }
@@ -384,14 +526,19 @@ impl Iterator for ReadSetIterator {
 
 impl ReadSetIterator {
     /// Instantiates a new iterator over the read sets for a set of FASTQs with defined read
-    /// structures.
+    /// structures.  When `keep_raw` is true, segment extraction is deferred — the resulting
+    /// `ReadSet`s carry only the raw bases/quals per input so that callers can re-segment
+    /// per-sample (or per-globals) downstream.  `min_len` is the minimum number of bases a
+    /// record must have for this iterator to yield it (or skip it as `TooFewBases`).
     pub fn new(
         read_structure: ReadStructure,
         source: FastqReader<Box<dyn BufRead + Send>>,
         skip_reasons: Vec<SkipReason>,
         source_index: usize,
+        keep_raw: bool,
+        min_len: usize,
     ) -> Self {
-        Self { read_structure, source, skip_reasons, source_index }
+        Self { read_structure, source, skip_reasons, source_index, keep_raw, min_len }
     }
 }
 
@@ -658,6 +805,46 @@ impl DemuxMetric {
 /// of the observed base (e.g. the expected barcode `AAN` will have zero mismatches relative to
 /// both the observed barcodes `AAA` and `AAN`).
 ///
+/// ## Per-sample read structures
+///
+/// In addition to the global `--read-structures`, the metadata TSV may include optional columns
+/// `read_structure_1`, `read_structure_2`, ..., `read_structure_<N>` (where `N` is the number of
+/// input FASTQs).  When any cell is non-empty for a sample, the per-sample read structures
+/// replace the global `--read-structures` for that sample — both for matching and for output
+/// extraction.
+///
+/// Per-sample structures support per-cell fall-back to the global `--read-structures`:
+///
+/// - A blank `read_structure_<i>` cell uses `--read-structures[i-1]` for that sample's input *i*.
+/// - A row whose `read_structure_<n>` cells are all blank uses `--read-structures` entirely for
+///   that sample (equivalent to omitting the columns for that sample only).
+/// - The unmatched pseudo-sample always uses the global `--read-structures`.
+///
+/// Constraints:
+///
+/// 1. The number of `read_structure_<n>` columns must equal `--read-structures.len()`.
+/// 2. The concatenated `B`-segment length must equal the `barcode` column length for every
+///    sample (computed from each sample's *effective* read structures, i.e. with fall-backs
+///    applied).
+///
+/// Different samples may have different per-input `(T, B, M, C)` segment counts (and hence
+/// produce different sets of output files).  This supports protocols with sample-dependent
+/// read structures (e.g. CODEC, where each sample may include a stagger spacer of varying
+/// length so that the position of the constant ligation base shifts per sample).
+///
+/// During matching, each sample's expected pattern is constructed from its effective read
+/// structure by filling `B`-segment positions from the `barcode` column and treating
+/// `M`/`S`/`C` segment positions as `N` wildcards.  All patterns are padded with trailing `N`s
+/// to a per-input matching window equal to the longest pre-template prefix across samples.
+///
+/// Example metadata TSV (CODEC stagger):
+///
+/// ```text
+/// sample_id  barcode         read_structure_1   read_structure_2
+/// S1         GATTACAGATTACA  3M7B1S+T           3M7B1S+T
+/// S2         TTTTTTTTTTTTTT  3M1S7B1S+T         3M1S7B1S+T
+/// ```
+///
 /// ## Outputs
 ///
 /// All outputs are generated in the provided `--output` directory.  For each sample plus the
@@ -699,6 +886,12 @@ pub(crate) struct Demux {
     inputs: Vec<PathBuf>,
 
     /// The read structures, one per input FASTQ in the same order.
+    ///
+    /// Per-sample read structures (see the `read_structure_<n>` metadata columns) take
+    /// precedence for each matched sample, and a blank cell falls back to the corresponding
+    /// `--read-structures` entry.  The unmatched pseudo-sample always uses
+    /// `--read-structures` for its output extraction.  The number of `read_structure_<n>`
+    /// columns must equal `--read-structures.len()`.
     #[clap(long, short = 'r' , required = true, num_args = 1..)]
     read_structures: Vec<ReadStructure>,
 
@@ -831,7 +1024,9 @@ impl Demux {
     }
 
     /// Creates one writer per sample per read segment in the provided read structures for
-    /// requested output type.
+    /// requested output type.  Each sample's writers are created from its per-sample read
+    /// structures when present; otherwise the global `read_structures` are used.  The
+    /// unmatched pseudo-sample always uses the global `read_structures`.
     /// # Errors:
     ///     - Will error if opening the output fails for any reason.
     fn create_writers(
@@ -843,14 +1038,15 @@ impl Demux {
     ) -> Result<Vec<SampleWriters<BufWriter<File>>>> {
         let mut samples_writers = Vec::with_capacity(sample_group.samples.len());
         for sample in &sample_group.samples {
+            let rs = sample.read_structures.as_deref().unwrap_or(read_structures);
             samples_writers.push(Self::create_sample_writers(
-                read_structures,
+                rs,
                 &sample.sample_id,
                 output_types,
                 output_dir,
             )?);
         }
-        // Add the unmatched 'sample'
+        // Add the unmatched 'sample' using the global read structures.
         samples_writers.push(Self::create_sample_writers(
             read_structures,
             unmatched_prefix,
@@ -1113,7 +1309,7 @@ impl Command for Demux {
             self.validate_and_prepare_inputs()?;
         let template_output = TemplateOutput::from_types(template_segment_types);
 
-        let sample_group = SampleGroup::from_file(&self.sample_metadata)?;
+        let sample_group = SampleGroup::from_file(&self.sample_metadata, &self.read_structures)?;
         info!(
             "{} samples loaded from file {:?}",
             sample_group.samples.len(),
@@ -1141,7 +1337,6 @@ impl Command for Demux {
         let unmatched_index = sample_writers.len() - 1;
         info!("Created sample and {} writers.", self.unmatched_prefix);
 
-        // Create the metrics as a Vec that is index sync'd with the sample group
         let mut sample_metrics = sample_group
             .samples
             .iter()
@@ -1149,23 +1344,55 @@ impl Command for Demux {
             .collect_vec();
         let mut unmatched_metric = DemuxMetric::new(self.unmatched_prefix.as_str(), ".");
 
-        // Setup the barcode matcher - the primary return from here is the index of the samp
-        let mut barcode_matcher = BarcodeMatcher::new(
-            &sample_group.samples,
-            u8::try_from(self.max_mismatches)?,
-            u8::try_from(self.min_mismatch_delta)?,
-            true,
-        );
+        let per_sample_rs = sample_group.has_per_sample_read_structures();
+        let prefix_lens = if per_sample_rs {
+            sample_group.matching_prefix_lens(&self.read_structures)?
+        } else {
+            Vec::new()
+        };
+        let matching_patterns = if per_sample_rs {
+            sample_group.build_matching_patterns(&self.read_structures, &prefix_lens)?
+        } else {
+            Vec::new()
+        };
 
+        let mut barcode_matcher = if per_sample_rs {
+            BarcodeMatcher::with_patterns(
+                &sample_group.samples,
+                matching_patterns,
+                u8::try_from(self.max_mismatches)?,
+                u8::try_from(self.min_mismatch_delta)?,
+                true,
+            )
+        } else {
+            BarcodeMatcher::new(
+                &sample_group.samples,
+                u8::try_from(self.max_mismatches)?,
+                u8::try_from(self.min_mismatch_delta)?,
+                true,
+            )
+        };
+
+        // In per-sample mode the iterator gates on the per-input matching-window length
+        // (prefix_lens[i]); the global read structure's full min_len would over-reject reads
+        // that satisfy a sample's shorter structure.  Re-segmentation downstream re-checks
+        // length against the matched sample's structure.
         let mut fq_iterators = fq_sources
             .zip(self.read_structures.clone())
             .enumerate()
             .map(|(source_index, (source, read_structure))| {
+                let min_len = if per_sample_rs {
+                    prefix_lens[source_index]
+                } else {
+                    read_structure.iter().map(|s| s.length().unwrap_or(1)).sum()
+                };
                 ReadSetIterator::new(
                     read_structure,
                     source,
                     self.skip_reasons.clone(),
                     source_index,
+                    per_sample_rs,
+                    min_len,
                 )
                 .read_ahead(1000, 1000)
             })
@@ -1179,6 +1406,7 @@ impl Command for Demux {
             .count_formatter(CountFormatterKind::Comma)
             .level(log::Level::Info)
             .build();
+        let allow_too_few = self.skip_reasons.contains(&SkipReason::TooFewBases);
         let mut skip_reasons: HashMap<SkipReason, usize> = HashMap::new();
         loop {
             let mut next_read_sets = Vec::with_capacity(fq_iterators.len());
@@ -1187,8 +1415,6 @@ impl Command for Demux {
                     next_read_sets.push(rec);
                 }
             }
-            // Either skip the reason if any FASTQ record could not be destructured, or break the
-            // loop if no read were found indicating EOF.
             if let Some(reason) = next_read_sets.iter().find_map(|read_set| read_set.skip_reason) {
                 let previous = skip_reasons.get(&reason).unwrap_or(&0);
                 skip_reasons.insert(reason, 1 + previous);
@@ -1203,10 +1429,48 @@ impl Command for Demux {
                 next_read_sets
             );
             let read_set = ReadSet::combine_readsets(next_read_sets);
-            if let Some(barcode_match) = barcode_matcher.assign(&read_set.sample_barcode_sequence())
-            {
-                sample_writers[barcode_match.best_match].write(&read_set, &template_output)?;
-                sample_metrics[barcode_match.best_match].templates += 1;
+            let observed: Vec<u8> = if per_sample_rs {
+                read_set.matching_window_bases(&prefix_lens)
+            } else {
+                read_set.sample_barcode_sequence()
+            };
+            if let Some(barcode_match) = barcode_matcher.assign(&observed) {
+                let matched_idx = barcode_match.best_match;
+                if per_sample_rs {
+                    let rs_for_sample = sample_group.samples[matched_idx]
+                        .read_structures
+                        .as_deref()
+                        .unwrap_or(&self.read_structures);
+                    match read_set.resegment(rs_for_sample) {
+                        Ok(resegmented) => {
+                            sample_writers[matched_idx].write(&resegmented, &template_output)?;
+                            sample_metrics[matched_idx].templates += 1;
+                        }
+                        Err(ResegmentError::TooShort(_)) if allow_too_few => {
+                            *skip_reasons.entry(SkipReason::TooFewBases).or_insert(0) += 1;
+                        }
+                        Err(e) => return Err(e.into_inner()),
+                    }
+                } else {
+                    sample_writers[matched_idx].write(&read_set, &template_output)?;
+                    sample_metrics[matched_idx].templates += 1;
+                }
+            } else if per_sample_rs {
+                // Iterator gating in per-sample mode is loosened to the matching prefix length,
+                // so a read can satisfy the prefix gate while being too short for the global
+                // read structure.  Treat such reads as `TooFewBases` skips on the unmatched
+                // path regardless of `--skip-reasons` — legacy mode would have rejected them at
+                // the iterator and per-sample mode opts the user into heterogeneous lengths.
+                match read_set.resegment(&self.read_structures) {
+                    Ok(resegmented) => {
+                        sample_writers[unmatched_index].write(&resegmented, &template_output)?;
+                        unmatched_metric.templates += 1;
+                    }
+                    Err(ResegmentError::TooShort(_)) => {
+                        *skip_reasons.entry(SkipReason::TooFewBases).or_insert(0) += 1;
+                    }
+                    Err(ResegmentError::Other(e)) => return Err(e),
+                }
             } else {
                 sample_writers[unmatched_index].write(&read_set, &template_output)?;
                 unmatched_metric.templates += 1;
@@ -1331,7 +1595,12 @@ mod tests {
     }
 
     fn read_set(segments: Vec<FastqSegment>) -> ReadSet {
-        ReadSet { header: "NOT_IMPORTANT".as_bytes().to_owned(), segments, skip_reason: None }
+        ReadSet {
+            header: "NOT_IMPORTANT".as_bytes().to_owned(),
+            segments,
+            raw_per_input: vec![],
+            skip_reason: None,
+        }
     }
 
     // ############################################################################################
@@ -3133,5 +3402,281 @@ mod tests {
         let (seq, quals) = rs.segments_for_source(2, &b_t);
         assert!(seq.is_empty());
         assert!(quals.is_empty());
+    }
+
+    // ############################################################################################
+    // Tests for per-sample read structures (CODEC-style stagger).
+    // ############################################################################################
+
+    /// Writes a per-sample-read-structures metadata TSV with columns:
+    ///     sample_id, barcode, read_structure_1, ..., read_structure_<n>
+    /// `samples` is a slice of (sample_id, barcode, [read_structure_per_input...]).
+    fn metadata_file_with_rs(tmpdir: &TempDir, samples: &[(&str, &str, &[&str])]) -> PathBuf {
+        let n_inputs = samples[0].2.len();
+        let mut header = String::from("sample_id\tbarcode");
+        for i in 1..=n_inputs {
+            header.push('\t');
+            header.push_str(&format!("read_structure_{i}"));
+        }
+        let mut lines = vec![header];
+        for (sid, bc, structs) in samples {
+            assert_eq!(structs.len(), n_inputs);
+            let mut line = format!("{sid}\t{bc}");
+            for s in structs.iter() {
+                line.push('\t');
+                line.push_str(s);
+            }
+            lines.push(line);
+        }
+        let path = tmpdir.path().join("metadata.tsv");
+        Io::default().write_lines(&path, lines).unwrap();
+        path
+    }
+
+    /// End-to-end CODEC stagger test:
+    ///   Sample S1 (no stagger):  3M7B1S+T   barcode = GATTACA
+    ///   Sample S2 (1bp stagger): 3M1S7B1S+T barcode = TTTTTTT
+    /// One paired-end read per sample, each with a 50bp template after the constant `T`
+    /// stagger anchor.  Verifies that:
+    ///   1. Each read is assigned to the correct sample.
+    ///   2. The output template starts at the right position (no template haircut for the
+    ///      shorter-stagger sample).
+    ///   3. The UMI (M) and sample-barcode (B) outputs reflect the per-sample structure.
+    #[test]
+    fn test_demux_codec_per_sample_read_structures_paired_end() {
+        let tmp = TempDir::new().unwrap();
+
+        // The global `--read-structures` is provided but should not be used for matched
+        // samples (they have their own).  Its per-input segment signature can differ from the
+        // per-sample structures; the unmatched output uses globals independently.
+        let read_structures =
+            vec![ReadStructure::from_str("+T").unwrap(), ReadStructure::from_str("+T").unwrap()];
+
+        let s1_template_r1 = "A".repeat(50);
+        let s1_template_r2 = "C".repeat(50);
+        // Sample 1, no stagger: NNN GATTACA T <template>
+        let s1_r1 = format!("AAA{}T{}", "GATTACA", s1_template_r1);
+        let s1_r2 = format!("CCC{}T{}", "GATTACA", s1_template_r2);
+
+        let s2_template_r1 = "G".repeat(50);
+        let s2_template_r2 = "T".repeat(50);
+        // Sample 2, 1bp stagger: NNN A TTTTTTT T <template>
+        let s2_r1 = format!("GGGA{}T{}", "TTTTTTT", s2_template_r1);
+        let s2_r2 = format!("TTTA{}T{}", "TTTTTTT", s2_template_r2);
+
+        let r1_file = fastq_file(&tmp, "r1", "ex", &[s1_r1.as_str(), s2_r1.as_str()]);
+        let r2_file = fastq_file(&tmp, "r2", "ex", &[s1_r2.as_str(), s2_r2.as_str()]);
+
+        let sample_metadata = metadata_file_with_rs(
+            &tmp,
+            &[
+                ("S1", "GATTACAGATTACA", &["3M7B1S+T", "3M7B1S+T"]),
+                ("S2", "TTTTTTTTTTTTTT", &["3M1S7B1S+T", "3M1S7B1S+T"]),
+            ],
+        );
+
+        let output_dir = tmp.path().join("output");
+        let demux_inputs = Demux {
+            inputs: vec![r1_file, r2_file],
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T', 'B', 'M'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['T'],
+        };
+        demux_inputs.execute().unwrap();
+
+        // Sample 1: per-sample RS = 3M7B1S+T for both inputs.  Expect 50bp template per read,
+        // 7bp barcode per read, 3bp UMI per read.
+        let s1_r1_reads = read_fastq(&output_dir.join("S1.R1.fq.gz"));
+        let s1_r2_reads = read_fastq(&output_dir.join("S1.R2.fq.gz"));
+        let s1_b1_reads = read_fastq(&output_dir.join("S1.I1.fq.gz"));
+        let s1_b2_reads = read_fastq(&output_dir.join("S1.I2.fq.gz"));
+        let s1_m1_reads = read_fastq(&output_dir.join("S1.U1.fq.gz"));
+        let s1_m2_reads = read_fastq(&output_dir.join("S1.U2.fq.gz"));
+
+        assert_eq!(s1_r1_reads.len(), 1, "S1 R1 should have one read");
+        assert_eq!(s1_r1_reads[0].seq, s1_template_r1.as_bytes());
+        assert_eq!(s1_r2_reads[0].seq, s1_template_r2.as_bytes());
+        assert_eq!(s1_b1_reads[0].seq, b"GATTACA");
+        assert_eq!(s1_b2_reads[0].seq, b"GATTACA");
+        assert_eq!(s1_m1_reads[0].seq, b"AAA");
+        assert_eq!(s1_m2_reads[0].seq, b"CCC");
+
+        // Sample 2: per-sample RS = 3M1S7B1S+T for both inputs.
+        let s2_r1_reads = read_fastq(&output_dir.join("S2.R1.fq.gz"));
+        let s2_r2_reads = read_fastq(&output_dir.join("S2.R2.fq.gz"));
+        let s2_b1_reads = read_fastq(&output_dir.join("S2.I1.fq.gz"));
+        let s2_m1_reads = read_fastq(&output_dir.join("S2.U1.fq.gz"));
+
+        assert_eq!(s2_r1_reads.len(), 1, "S2 R1 should have one read");
+        assert_eq!(s2_r1_reads[0].seq, s2_template_r1.as_bytes());
+        assert_eq!(s2_r2_reads[0].seq, s2_template_r2.as_bytes());
+        assert_eq!(s2_b1_reads[0].seq, b"TTTTTTT");
+        assert_eq!(s2_m1_reads[0].seq, b"GGG");
+
+        // The unmatched outputs (using globals `+T +T`) only have R*.fq.gz files.  All reads
+        // matched, so they should be empty.
+        let unmatched_r1 = read_fastq(&output_dir.join("unmatched.R1.fq.gz"));
+        let unmatched_r2 = read_fastq(&output_dir.join("unmatched.R2.fq.gz"));
+        assert!(unmatched_r1.is_empty(), "unmatched R1 should be empty");
+        assert!(unmatched_r2.is_empty(), "unmatched R2 should be empty");
+    }
+
+    /// Ensures that when no per-sample read structures are present, behaviour is identical
+    /// to the legacy code path (uses global `--read-structures`).
+    #[test]
+    fn test_demux_falls_back_to_global_read_structures() {
+        let tmp = TempDir::new().unwrap();
+        let read_structures = vec![ReadStructure::from_str("17B100T").unwrap()];
+        let s1_barcode = "AAAAAAAAGATTACAGA";
+        let sample_metadata = metadata_file(
+            &tmp,
+            &[s1_barcode, "CCCCCCCCGATTACAGA", "GGGGGGGGGATTACAGA", "GGGGGGTTGATTACAGA"],
+        );
+        let input_files =
+            vec![fastq_file(&tmp, "ex", "ex", &[&(s1_barcode.to_owned() + &"A".repeat(100))])];
+
+        let output_dir = tmp.path().join("output");
+        let demux_inputs = Demux {
+            inputs: input_files,
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['T'],
+        };
+        demux_inputs.execute().unwrap();
+
+        let fq_reads = read_fastq(&output_dir.join("Sample0000.R1.fq.gz"));
+        assert_eq!(fq_reads.len(), 1);
+        assert_eq!(fq_reads[0].seq, "A".repeat(100).as_bytes());
+    }
+
+    /// Errors when per-sample `read_structure_<n>` columns disagree with the number of
+    /// `--read-structures` entries.
+    #[test]
+    fn test_demux_errors_when_per_sample_input_count_mismatches_global() {
+        let tmp = TempDir::new().unwrap();
+        let r1_file =
+            fastq_file(&tmp, "r1", "ex", &[format!("AAAGATTACAT{}", "A".repeat(50)).as_str()]);
+        // Metadata declares 1 read_structure column, but globals declare 2 inputs.
+        let sample_metadata = metadata_file_with_rs(&tmp, &[("S1", "GATTACA", &["3M7B1S+T"])]);
+
+        let demux_inputs = Demux {
+            inputs: vec![r1_file.clone(), r1_file],
+            read_structures: vec![
+                ReadStructure::from_str("3M7B+T").unwrap(),
+                ReadStructure::from_str("3M7B+T").unwrap(),
+            ],
+            sample_metadata,
+            output_types: vec!['T'],
+            output: tmp.path().join("output"),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['T'],
+        };
+        let err = demux_inputs.execute().unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("`read_structure_<n>` column(s)") && msg.contains("--read-structures"),
+            "got: {msg}",
+        );
+    }
+
+    /// Per-sample read structures may have a different `(T, B, M, C)` segment signature than
+    /// the global `--read-structures` — different samples may produce different sets of
+    /// output files, and the unmatched output uses the global structures independently.
+    #[test]
+    fn test_demux_per_sample_signature_may_differ_from_global() {
+        let tmp = TempDir::new().unwrap();
+        // Per-sample has (T=1, B=1, M=1, C=0); global has (T=1, B=1, M=0, C=0) — M counts differ.
+        let r1 = format!("AAAGATTACAT{}", "A".repeat(50));
+        let r1_file = fastq_file(&tmp, "r1", "ex", &[r1.as_str()]);
+        let sample_metadata = metadata_file_with_rs(&tmp, &[("S1", "GATTACA", &["3M7B1S+T"])]);
+
+        let demux_inputs = Demux {
+            inputs: vec![r1_file],
+            read_structures: vec![ReadStructure::from_str("7B+T").unwrap()],
+            sample_metadata,
+            output_types: vec!['T', 'M'],
+            output: tmp.path().join("output").clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['T'],
+        };
+        let output_dir = demux_inputs.output.clone();
+        demux_inputs.execute().unwrap();
+        // S1 produces R1 + U1 (matches per-sample 3M7B1S+T → 1T, 1M).
+        let s1_r1 = read_fastq(&output_dir.join("S1.R1.fq.gz"));
+        let s1_u1 = read_fastq(&output_dir.join("S1.U1.fq.gz"));
+        assert_eq!(s1_r1.len(), 1);
+        assert_eq!(s1_u1.len(), 1);
+        assert_eq!(s1_u1[0].seq, b"AAA");
+        // Globals (7B+T) have no M segment, so unmatched only writes R1; the file may not even
+        // exist if no unmatched reads occurred.  In this test, the read matches S1, so there
+        // are no unmatched records.
+    }
+
+    /// Regression: in per-sample mode the iterator gates on the per-sample matching prefix,
+    /// which can be shorter than the global `--read-structures` minimum.  A read that satisfies
+    /// the prefix gate but does not match any sample reaches the unmatched branch where
+    /// resegmentation against the global structure would fail on length.  The run must not
+    /// abort; the read must be counted as a `TooFewBases` skip independently of `--skip-reasons`.
+    #[test]
+    fn test_demux_per_sample_unmatched_short_read_does_not_abort() {
+        let tmp = TempDir::new().unwrap();
+        // Global is 8B+T per input (min_len 9); sample S1 has 3B+T per input (prefix 3).
+        let read_structures = vec![
+            ReadStructure::from_str("8B+T").unwrap(),
+            ReadStructure::from_str("8B+T").unwrap(),
+        ];
+        let sample_metadata = metadata_file_with_rs(&tmp, &[("S1", "AAAAAA", &["3B+T", "3B+T"])]);
+        // 3-byte reads per input that don't match S1's "AAA"+"AAA" matching pattern.
+        let r1_file = fastq_file(&tmp, "r1", "ex", &["TTT"]);
+        let r2_file = fastq_file(&tmp, "r2", "ex", &["TTT"]);
+
+        let output_dir = tmp.path().join("output");
+        let demux_inputs = Demux {
+            inputs: vec![r1_file, r2_file],
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T', 'B'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            // Critically NOT requesting too-few-bases skip; legacy resegment path would abort.
+            skip_reasons: vec![],
+            template_types: vec!['T'],
+        };
+        demux_inputs.execute().unwrap();
+
+        let metrics_path = output_dir.join("demux-metrics.txt");
+        let metrics: Vec<DemuxMetric> = DelimFile::default().read_tsv(&metrics_path).unwrap();
+        let demuxed: usize = metrics.iter().map(|m| m.templates).sum();
+        assert_eq!(demuxed, 0, "no reads should be demuxed; the unmatched read is too short");
     }
 }

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -97,14 +97,10 @@ enum ResegmentError {
     Other(anyhow::Error),
 }
 
-impl ResegmentError {
-    /// Consumes the error and returns the underlying [`anyhow::Error`].
-    fn into_inner(self) -> anyhow::Error {
-        match self {
-            ResegmentError::TooShort(e) | ResegmentError::Other(e) => e,
-        }
-    }
-}
+/// Hint appended to a too-short-read abort, pointing the user at the flag that converts the
+/// abort into a counted skip.
+const TOO_FEW_BASES_HINT: &str =
+    "pass `--skip-reasons too-few-bases` to skip reads that are too short instead of aborting";
 
 /// One unit of FASTQ records separated into their component read segments.
 #[derive(PartialEq, Debug, Clone)]
@@ -227,6 +223,19 @@ impl ReadSet {
                         });
                     }
                 };
+                // A variable-length template (`+T`) extracts to zero bases when the read ends
+                // exactly at the template's start.  The read-structure crate returns `Ok(empty)`
+                // rather than a length error, but emitting a zero-length FASTQ record is invalid,
+                // so treat such a read as too short (consistent with a genuinely truncated read).
+                if seg.kind == SegmentType::Template && s.is_empty() {
+                    return Err(ResegmentError::TooShort(anyhow!(
+                        "Read structure ({}) produced a zero-length template for FASTQ record {} \
+                         (len: {})",
+                        rs,
+                        String::from_utf8_lossy(&self.header),
+                        raw.bases.len(),
+                    )));
+                }
                 segments.push(FastqSegment {
                     seq: s.to_vec(),
                     quals: q.to_vec(),
@@ -1449,7 +1458,10 @@ impl Command for Demux {
                         Err(ResegmentError::TooShort(_)) if allow_too_few => {
                             *skip_reasons.entry(SkipReason::TooFewBases).or_insert(0) += 1;
                         }
-                        Err(e) => return Err(e.into_inner()),
+                        Err(ResegmentError::TooShort(e)) => {
+                            return Err(e.context(TOO_FEW_BASES_HINT));
+                        }
+                        Err(ResegmentError::Other(e)) => return Err(e),
                     }
                 } else {
                     sample_writers[matched_idx].write(&read_set, &template_output)?;
@@ -1457,18 +1469,19 @@ impl Command for Demux {
                 }
             } else if per_sample_rs {
                 // Iterator gating in per-sample mode is loosened to the matching prefix length,
-                // so a read can satisfy the prefix gate while being too short for the global
-                // read structure.  Treat such reads as `TooFewBases` skips on the unmatched
-                // path regardless of `--skip-reasons` — legacy mode would have rejected them at
-                // the iterator and per-sample mode opts the user into heterogeneous lengths.
+                // so a read can clear the prefix gate while being too short for the global read
+                // structure used on the unmatched path.  Honor `--skip-reasons too-few-bases`
+                // exactly as the matched and legacy paths do: skip when requested, otherwise
+                // abort with a remedy hint.
                 match read_set.resegment(&self.read_structures) {
                     Ok(resegmented) => {
                         sample_writers[unmatched_index].write(&resegmented, &template_output)?;
                         unmatched_metric.templates += 1;
                     }
-                    Err(ResegmentError::TooShort(_)) => {
+                    Err(ResegmentError::TooShort(_)) if allow_too_few => {
                         *skip_reasons.entry(SkipReason::TooFewBases).or_insert(0) += 1;
                     }
+                    Err(ResegmentError::TooShort(e)) => return Err(e.context(TOO_FEW_BASES_HINT)),
                     Err(ResegmentError::Other(e)) => return Err(e),
                 }
             } else {
@@ -3513,13 +3526,18 @@ mod tests {
         let s2_r1_reads = read_fastq(&output_dir.join("S2.R1.fq.gz"));
         let s2_r2_reads = read_fastq(&output_dir.join("S2.R2.fq.gz"));
         let s2_b1_reads = read_fastq(&output_dir.join("S2.I1.fq.gz"));
+        let s2_b2_reads = read_fastq(&output_dir.join("S2.I2.fq.gz"));
         let s2_m1_reads = read_fastq(&output_dir.join("S2.U1.fq.gz"));
+        let s2_m2_reads = read_fastq(&output_dir.join("S2.U2.fq.gz"));
 
         assert_eq!(s2_r1_reads.len(), 1, "S2 R1 should have one read");
         assert_eq!(s2_r1_reads[0].seq, s2_template_r1.as_bytes());
         assert_eq!(s2_r2_reads[0].seq, s2_template_r2.as_bytes());
         assert_eq!(s2_b1_reads[0].seq, b"TTTTTTT");
+        // Second input's barcode/UMI must also be resegmented per the staggered structure.
+        assert_eq!(s2_b2_reads[0].seq, b"TTTTTTT");
         assert_eq!(s2_m1_reads[0].seq, b"GGG");
+        assert_eq!(s2_m2_reads[0].seq, b"TTT");
 
         // The unmatched outputs (using globals `+T +T`) only have R*.fq.gz files.  All reads
         // matched, so they should be empty.
@@ -3527,6 +3545,61 @@ mod tests {
         let unmatched_r2 = read_fastq(&output_dir.join("unmatched.R2.fq.gz"));
         assert!(unmatched_r1.is_empty(), "unmatched R1 should be empty");
         assert!(unmatched_r2.is_empty(), "unmatched R2 should be empty");
+    }
+
+    /// End-to-end single-input CODEC-style test with two samples at different staggers (the most
+    /// common inline-index layout).  Exercises heterogeneous per-sample prefix lengths within a
+    /// single input and verifies that the shorter-stagger sample's template is not haircut to the
+    /// longer matching window.
+    #[test]
+    fn test_demux_codec_per_sample_single_input() {
+        let tmp = TempDir::new().unwrap();
+        // Global is only used for unmatched reads.
+        let read_structures = vec![ReadStructure::from_str("+T").unwrap()];
+
+        let s1_template = "A".repeat(30);
+        let s2_template = "C".repeat(30);
+        // S1, no stagger:  NNN GATTACA T <template>          (pre-template = 11)
+        let s1_r1 = format!("AAA{}T{}", "GATTACA", s1_template);
+        // S2, 1bp stagger: NNN A TTTTTTT T <template>        (pre-template = 12)
+        let s2_r1 = format!("GGGA{}T{}", "TTTTTTT", s2_template);
+        let r1_file = fastq_file(&tmp, "r1", "ex", &[s1_r1.as_str(), s2_r1.as_str()]);
+
+        let sample_metadata = metadata_file_with_rs(
+            &tmp,
+            &[("S1", "GATTACA", &["3M7B1S+T"]), ("S2", "TTTTTTT", &["3M1S7B1S+T"])],
+        );
+
+        let output_dir = tmp.path().join("output");
+        let demux_inputs = Demux {
+            inputs: vec![r1_file],
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T', 'B', 'M'],
+            output: output_dir.clone(),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons: vec![],
+            template_types: vec!['T'],
+        };
+        demux_inputs.execute().unwrap();
+
+        // S1 (shorter stagger): template must start at offset 11, not the 12-base window.
+        let s1_r1_reads = read_fastq(&output_dir.join("S1.R1.fq.gz"));
+        assert_eq!(s1_r1_reads.len(), 1, "S1 should have one read");
+        assert_eq!(s1_r1_reads[0].seq, s1_template.as_bytes(), "S1 template must not be haircut");
+        assert_eq!(read_fastq(&output_dir.join("S1.I1.fq.gz"))[0].seq, b"GATTACA");
+        assert_eq!(read_fastq(&output_dir.join("S1.U1.fq.gz"))[0].seq, b"AAA");
+
+        // S2 (longer stagger): template starts at offset 12.
+        let s2_r1_reads = read_fastq(&output_dir.join("S2.R1.fq.gz"));
+        assert_eq!(s2_r1_reads.len(), 1, "S2 should have one read");
+        assert_eq!(s2_r1_reads[0].seq, s2_template.as_bytes());
+        assert_eq!(read_fastq(&output_dir.join("S2.I1.fq.gz"))[0].seq, b"TTTTTTT");
+        assert_eq!(read_fastq(&output_dir.join("S2.U1.fq.gz"))[0].seq, b"GGG");
     }
 
     /// Ensures that when no per-sample read structures are present, behaviour is identical
@@ -3638,28 +3711,123 @@ mod tests {
         // are no unmatched records.
     }
 
-    /// Regression: in per-sample mode the iterator gates on the per-sample matching prefix,
-    /// which can be shorter than the global `--read-structures` minimum.  A read that satisfies
-    /// the prefix gate but does not match any sample reaches the unmatched branch where
-    /// resegmentation against the global structure would fail on length.  The run must not
-    /// abort; the read must be counted as a `TooFewBases` skip independently of `--skip-reasons`.
-    #[test]
-    fn test_demux_per_sample_unmatched_short_read_does_not_abort() {
-        let tmp = TempDir::new().unwrap();
-        // Global is 8B+T per input (min_len 9); sample S1 has 3B+T per input (prefix 3).
+    /// Builds a per-sample demux scenario in which a read clears the (loosened) per-sample
+    /// prefix gate, matches no sample, and is too short for the global `--read-structures` when
+    /// resegmented on the unmatched path.  `skip_reasons` is supplied by the caller.
+    fn unmatched_short_read_demux(tmp: &TempDir, skip_reasons: Vec<SkipReason>) -> Demux {
+        // Global is 8B+T per input; sample S1 has 3B+T per input (prefix 3).
         let read_structures = vec![
             ReadStructure::from_str("8B+T").unwrap(),
             ReadStructure::from_str("8B+T").unwrap(),
         ];
-        let sample_metadata = metadata_file_with_rs(&tmp, &[("S1", "AAAAAA", &["3B+T", "3B+T"])]);
+        let sample_metadata = metadata_file_with_rs(tmp, &[("S1", "AAAAAA", &["3B+T", "3B+T"])]);
         // 3-byte reads per input that don't match S1's "AAA"+"AAA" matching pattern.
-        let r1_file = fastq_file(&tmp, "r1", "ex", &["TTT"]);
-        let r2_file = fastq_file(&tmp, "r2", "ex", &["TTT"]);
+        let r1_file = fastq_file(tmp, "r1", "ex", &["TTT"]);
+        let r2_file = fastq_file(tmp, "r2", "ex", &["TTT"]);
+
+        Demux {
+            inputs: vec![r1_file, r2_file],
+            read_structures,
+            sample_metadata,
+            output_types: vec!['T', 'B'],
+            output: tmp.path().join("output"),
+            unmatched_prefix: "unmatched".to_owned(),
+            max_mismatches: 1,
+            min_mismatch_delta: 2,
+            threads: 5,
+            compression_level: 5,
+            skip_reasons,
+            template_types: vec!['T'],
+        }
+    }
+
+    /// In per-sample mode the iterator gates on the per-sample matching prefix, which can be
+    /// shorter than the global `--read-structures` minimum.  A read that clears the prefix gate
+    /// but matches no sample reaches the unmatched branch, where resegmentation against the
+    /// global structure fails on length.  Without `--skip-reasons too-few-bases` this is fatal
+    /// (consistent with the matched and legacy paths) and the error names the remedy.
+    #[test]
+    fn test_demux_per_sample_unmatched_short_read_aborts_without_flag() {
+        let tmp = TempDir::new().unwrap();
+        let demux_inputs = unmatched_short_read_demux(&tmp, vec![]);
+        let err = demux_inputs.execute().unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("--skip-reasons too-few-bases"), "got: {msg}");
+    }
+
+    /// With `--skip-reasons too-few-bases`, the same too-short unmatched read is counted as a
+    /// skip rather than aborting, and the run completes with no reads demultiplexed.
+    #[test]
+    fn test_demux_per_sample_unmatched_short_read_skipped_with_flag() {
+        let tmp = TempDir::new().unwrap();
+        let demux_inputs = unmatched_short_read_demux(&tmp, vec![SkipReason::TooFewBases]);
+        let output_dir = demux_inputs.output.clone();
+        demux_inputs.execute().unwrap();
+
+        let metrics_path = output_dir.join("demux-metrics.txt");
+        let metrics: Vec<DemuxMetric> = DelimFile::default().read_tsv(&metrics_path).unwrap();
+        let demuxed: usize = metrics.iter().map(|m| m.templates).sum();
+        assert_eq!(demuxed, 0, "no reads should be demuxed; the unmatched read is too short");
+    }
+
+    /// A read whose bases end exactly at the start of a variable-length template (`+T`) has zero
+    /// template bases.  The underlying read-structure crate returns an empty slice (not an error)
+    /// for the trailing `+T`, so without an explicit guard `resegment` would emit a zero-length
+    /// FASTQ record.  Such a read must instead be treated as `TooShort`.
+    #[test]
+    fn test_resegment_zero_length_template_is_too_short() {
+        let read_set = ReadSet {
+            header: b"ex".to_vec(),
+            segments: vec![],
+            raw_per_input: vec![RawInput {
+                bases: b"ACGTACGT".to_vec(),
+                quals: b"FFFFFFFF".to_vec(),
+            }],
+            skip_reason: None,
+        };
+        // 8B consumes all 8 bases, leaving the `+T` template with zero bases.
+        let read_structures = vec![ReadStructure::from_str("8B+T").unwrap()];
+        let result = read_set.resegment(&read_structures);
+        assert!(
+            matches!(result, Err(ResegmentError::TooShort(_))),
+            "expected TooShort for a read with no template bases, got {result:?}",
+        );
+    }
+
+    /// A variable-length template with at least one base resegments normally (guards against the
+    /// zero-length fix over-rejecting non-empty templates).
+    #[test]
+    fn test_resegment_one_base_template_is_ok() {
+        let read_set = ReadSet {
+            header: b"ex".to_vec(),
+            segments: vec![],
+            raw_per_input: vec![RawInput {
+                bases: b"ACGTACGTT".to_vec(),
+                quals: b"FFFFFFFFF".to_vec(),
+            }],
+            skip_reason: None,
+        };
+        // 8B consumes 8 bases, leaving a single `T` base for the template.
+        let read_structures = vec![ReadStructure::from_str("8B+T").unwrap()];
+        let resegmented = read_set.resegment(&read_structures).expect("should resegment");
+        let template: Vec<u8> =
+            resegmented.template_segments().flat_map(|s| s.seq.clone()).collect();
+        assert_eq!(template, b"T");
+    }
+
+    /// End-to-end: a matched per-sample read whose bases end exactly at the template start must be
+    /// counted as a `TooFewBases` skip, not written as a zero-length template record.
+    #[test]
+    fn test_demux_per_sample_zero_length_template_is_skipped() {
+        let tmp = TempDir::new().unwrap();
+        // Per-sample RS 8B+T (prefix 8); the read is exactly 8 bases (barcode only, no template).
+        let sample_metadata = metadata_file_with_rs(&tmp, &[("S1", "ACGTACGT", &["8B+T"])]);
+        let r1_file = fastq_file(&tmp, "r1", "ex", &["ACGTACGT"]);
 
         let output_dir = tmp.path().join("output");
         let demux_inputs = Demux {
-            inputs: vec![r1_file, r2_file],
-            read_structures,
+            inputs: vec![r1_file],
+            read_structures: vec![ReadStructure::from_str("8B+T").unwrap()],
             sample_metadata,
             output_types: vec!['T', 'B'],
             output: output_dir.clone(),
@@ -3668,15 +3836,19 @@ mod tests {
             min_mismatch_delta: 2,
             threads: 5,
             compression_level: 5,
-            // Critically NOT requesting too-few-bases skip; legacy resegment path would abort.
-            skip_reasons: vec![],
+            // Tolerate the too-short read so the matched path skips rather than aborts.
+            skip_reasons: vec![SkipReason::TooFewBases],
             template_types: vec!['T'],
         };
         demux_inputs.execute().unwrap();
 
+        // No template record should have been written for S1 (no zero-length record).
+        let s1_r1 = read_fastq(&output_dir.join("S1.R1.fq.gz"));
+        assert!(s1_r1.is_empty(), "no zero-length template record should be written");
+
         let metrics_path = output_dir.join("demux-metrics.txt");
         let metrics: Vec<DemuxMetric> = DelimFile::default().read_tsv(&metrics_path).unwrap();
         let demuxed: usize = metrics.iter().map(|m| m.templates).sum();
-        assert_eq!(demuxed, 0, "no reads should be demuxed; the unmatched read is too short");
+        assert_eq!(demuxed, 0, "the boundary read must be skipped, not demuxed");
     }
 }

--- a/src/lib/barcode_matching.rs
+++ b/src/lib/barcode_matching.rs
@@ -58,21 +58,63 @@ impl BarcodeMatcher {
         min_mismatch_delta: u8,
         use_cache: bool,
     ) -> Self {
+        let patterns: Vec<Vec<u8>> =
+            samples.iter().map(|s| s.barcode.as_bytes().to_vec()).collect();
+        Self::with_patterns(samples, patterns, max_mismatches, min_mismatch_delta, use_cache)
+    }
+
+    /// Instantiates a new ``BarcodeMatcher`` using user-supplied per-sample matching patterns
+    /// instead of `sample.barcode`. Patterns must be 1:1 with `samples`. The patterns may
+    /// contain `N` (and other IUPAC bases); `N`s in the expected pattern are treated as
+    /// wildcards by [`BarcodeMatcher::count_mismatches`].
+    ///
+    /// **Note:** the matcher's *internal* clone of each `Sample` has its `barcode` field
+    /// overwritten with the (uppercased) matching pattern, so that
+    /// [`Self::expected_barcode_length`] and any error messages reflect the pattern length
+    /// rather than the user-facing barcode length.  The caller's `samples` slice is not
+    /// modified.  The matching loop in `Demux::execute` relies on this: the observed bytes
+    /// it submits to [`Self::assign`] are the raw matching window (= pattern length), which
+    /// would otherwise mismatch the shorter user-facing barcode length.
+    ///
+    /// # Panics
+    /// - Will panic if `samples` is empty.
+    /// - Will panic if any pattern is the empty byte slice.
+    /// - Will panic if `patterns.len() != samples.len()`.
+    /// - Will panic if patterns are not all the same length.
+    #[must_use]
+    pub fn with_patterns(
+        samples: &[Sample],
+        patterns: Vec<Vec<u8>>,
+        max_mismatches: u8,
+        min_mismatch_delta: u8,
+        use_cache: bool,
+    ) -> Self {
         assert!(!samples.is_empty(), "Must provide at least one sample");
         assert!(
-            samples.iter().all(|b| !b.barcode.is_empty()),
-            "Sample barcode cannot be empty string"
+            patterns.len() == samples.len(),
+            "Number of patterns ({}) must match number of samples ({})",
+            patterns.len(),
+            samples.len(),
+        );
+        assert!(patterns.iter().all(|p| !p.is_empty()), "Sample barcode cannot be empty string");
+        let pattern_len = patterns[0].len();
+        assert!(
+            patterns.iter().all(|p| p.len() == pattern_len),
+            "All sample matching patterns must have the same length",
         );
 
         let mut max_ns_in_barcodes = 0;
         let mut modified_samples = samples.to_vec();
         let mut sample_barcodes = Vec::with_capacity(samples.len());
-        for sample in &mut modified_samples {
-            sample.barcode = sample.barcode.to_ascii_uppercase();
-            let bytes = sample.barcode.as_bytes();
-            let num_ns: usize = bytes.iter().filter(|&&b| byte_is_nocall(b)).count();
+        for (sample, pattern) in modified_samples.iter_mut().zip(patterns.into_iter()) {
+            let pattern_upper: Vec<u8> = pattern.iter().map(u8::to_ascii_uppercase).collect();
+            // Replace the in-matcher copy of `barcode` with the pattern so that error messages
+            // show what was actually being matched. The caller's samples are not modified.
+            sample.barcode = String::from_utf8(pattern_upper.clone())
+                .expect("matching pattern must be valid UTF-8");
+            let num_ns: usize = pattern_upper.iter().filter(|&&b| byte_is_nocall(b)).count();
             max_ns_in_barcodes = max_ns_in_barcodes.max(num_ns);
-            sample_barcodes.push(encode(bytes));
+            sample_barcodes.push(encode(&pattern_upper));
         }
         Self {
             samples: modified_samples,
@@ -197,6 +239,7 @@ mod tests {
         Sample {
             barcode: barcode.to_string(),
             sample_id: format!("sample_{idx}").to_string(),
+            read_structures: None,
             ordinal: idx,
         }
     }

--- a/src/lib/barcode_matching.rs
+++ b/src/lib/barcode_matching.rs
@@ -58,21 +58,66 @@ impl BarcodeMatcher {
         min_mismatch_delta: u8,
         use_cache: bool,
     ) -> Self {
+        let patterns: Vec<Vec<u8>> =
+            samples.iter().map(|s| s.barcode.as_bytes().to_vec()).collect();
+        Self::with_patterns(samples, patterns, max_mismatches, min_mismatch_delta, use_cache)
+    }
+
+    /// Instantiates a new ``BarcodeMatcher`` using user-supplied per-sample matching patterns
+    /// instead of `sample.barcode`. Patterns must be 1:1 with `samples`. The patterns may
+    /// contain `N` (and other IUPAC bases); `N`s in the expected pattern are treated as
+    /// wildcards by [`BarcodeMatcher::count_mismatches`].
+    ///
+    /// **Note:** the matcher's *internal* clone of each `Sample` has its `barcode` field
+    /// overwritten with the (uppercased) matching pattern, so that
+    /// [`Self::expected_barcode_length`] and any error messages reflect the pattern length
+    /// rather than the user-facing barcode length.  The caller's `samples` slice is not
+    /// modified.  The matching loop in `Demux::execute` relies on this: the observed bytes
+    /// it submits to [`Self::assign`] are the raw matching window (= pattern length), which
+    /// would otherwise mismatch the shorter user-facing barcode length.
+    ///
+    /// # Panics
+    /// - Will panic if `samples` is empty.
+    /// - Will panic if any pattern is the empty byte slice.
+    /// - Will panic if `patterns.len() != samples.len()`.
+    /// - Will panic if patterns are not all the same length.
+    #[must_use]
+    pub fn with_patterns(
+        samples: &[Sample],
+        patterns: Vec<Vec<u8>>,
+        max_mismatches: u8,
+        min_mismatch_delta: u8,
+        use_cache: bool,
+    ) -> Self {
         assert!(!samples.is_empty(), "Must provide at least one sample");
         assert!(
-            samples.iter().all(|b| !b.barcode.is_empty()),
-            "Sample barcode cannot be empty string"
+            patterns.len() == samples.len(),
+            "Number of patterns ({}) must match number of samples ({})",
+            patterns.len(),
+            samples.len(),
+        );
+        assert!(
+            patterns.iter().all(|p| !p.is_empty()),
+            "Sample matching pattern cannot be empty string",
+        );
+        let pattern_len = patterns[0].len();
+        assert!(
+            patterns.iter().all(|p| p.len() == pattern_len),
+            "All sample matching patterns must have the same length",
         );
 
         let mut max_ns_in_barcodes = 0;
         let mut modified_samples = samples.to_vec();
         let mut sample_barcodes = Vec::with_capacity(samples.len());
-        for sample in &mut modified_samples {
-            sample.barcode = sample.barcode.to_ascii_uppercase();
-            let bytes = sample.barcode.as_bytes();
-            let num_ns: usize = bytes.iter().filter(|&&b| byte_is_nocall(b)).count();
+        for (sample, pattern) in modified_samples.iter_mut().zip(patterns.into_iter()) {
+            let pattern_upper: Vec<u8> = pattern.iter().map(u8::to_ascii_uppercase).collect();
+            // Replace the in-matcher copy of `barcode` with the pattern so that error messages
+            // show what was actually being matched. The caller's samples are not modified.
+            sample.barcode = String::from_utf8(pattern_upper.clone())
+                .expect("matching pattern must be valid UTF-8");
+            let num_ns: usize = pattern_upper.iter().filter(|&&b| byte_is_nocall(b)).count();
             max_ns_in_barcodes = max_ns_in_barcodes.max(num_ns);
-            sample_barcodes.push(encode(bytes));
+            sample_barcodes.push(encode(&pattern_upper));
         }
         Self {
             samples: modified_samples,
@@ -197,6 +242,7 @@ mod tests {
         Sample {
             barcode: barcode.to_string(),
             sample_id: format!("sample_{idx}").to_string(),
+            read_structures: None,
             ordinal: idx,
         }
     }

--- a/src/lib/samples.rs
+++ b/src/lib/samples.rs
@@ -1,34 +1,38 @@
 use crate::is_valid_iupac;
 
-use anyhow::Result;
-use fgoxide::io::DelimFile;
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use fgoxide::io::Io;
 use itertools::Itertools;
-use serde::Deserialize;
-use serde_aux::prelude::*;
-use std::collections::HashSet;
-use std::collections::hash_map::RandomState;
+use read_structure::{ReadStructure, SegmentType};
 use std::fmt::{self, Display};
 use std::path::Path;
+use std::str::FromStr;
 
 const DEFAULT_FILE_DELIMETER: u8 = b'\t';
+const SAMPLE_ID_HEADER: &str = "sample_id";
+const BARCODE_HEADER: &str = "barcode";
+const READ_STRUCTURE_PREFIX: &str = "read_structure_";
 
 /// Struct for describing a single sample and metadata associated with that sample.
-#[derive(Clone, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Sample {
     /// ID of the sample or library
     pub sample_id: String,
     /// DNA barcode associated with the sample
     pub barcode: String,
-    /// index of the sample in the [`SampleGroup`] object, used for syncing indices across
-    /// different structs
-    #[serde(skip_deserializing)]
+    /// Optional per-sample read structures (one per input FASTQ).  When present, these
+    /// override the global `--read-structures` for this sample, both for matching pattern
+    /// construction and for output extraction.
+    pub read_structures: Option<Vec<ReadStructure>>,
+    /// Index of the sample in the [`SampleGroup`] object, used for syncing indices across
+    /// different structs.
     pub(crate) ordinal: usize,
 }
 
 impl Display for Sample {
     /// Implements a nice format display for the [`Sample`] struct.
     /// E.g. A sample with ordinal 2, name test-sample, and barcode GATTACA would look like:
-    /// Sample(0002) - { name: test-sample    barcode: GATTACA}
+    /// Sample(0002) - { name: test-sample    barcode: GATTACA }
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -44,35 +48,41 @@ impl Sample {
     /// # Panics
     ///   - Panics if sample name is empty string.
     ///   - Panics if barcode is empty string.
-    ///   - Panics if barcode has bases other than A, C, G, T, or N/n/.
+    ///   - Panics if barcode has bases other than A, C, G, T, U, R, Y, S, W, K, M, D, V, H, B, or
+    ///     N/n/.
     #[must_use]
     pub fn new(ordinal: usize, name: String, barcode: String) -> Self {
+        Self::with_read_structures(ordinal, name, barcode, None)
+    }
+
+    /// Like [`Sample::new`] but allows attaching per-sample read structures.
+    #[must_use]
+    pub fn with_read_structures(
+        ordinal: usize,
+        name: String,
+        barcode: String,
+        read_structures: Option<Vec<ReadStructure>>,
+    ) -> Self {
         assert!(!name.is_empty(), "Sample name cannot be empty");
         assert!(!barcode.is_empty(), "Sample barcode cannot be empty");
         assert!(
             barcode.as_bytes().iter().all(|&b| is_valid_iupac(b)),
             "All sample barcode bases must be one of A, C, G, T, U, R, Y, S, W, K, M, D, V, H, B, N"
         );
-        Self { sample_id: name, barcode, ordinal }
+        Self { sample_id: name, barcode, read_structures, ordinal }
     }
 
-    /// Returns the header line expected by serde when deserializing
+    /// Returns the header line expected by the metadata file deserializer.  Only the two required
+    /// columns are reported; per-sample `read_structure_<n>` columns are optional.
     #[must_use]
     pub fn deserialize_header_line() -> String {
-        let field_names = serde_introspect::<Self>();
-        let skip_deserialize_fields: HashSet<&str, RandomState> = HashSet::from_iter(["ordinal"]);
-        let final_field_names: Vec<String> = field_names
-            .iter()
-            .filter(|&&f| !skip_deserialize_fields.contains(f))
-            .map(|&f| f.to_owned())
-            .collect();
-        final_field_names.join("\t")
+        format!("{SAMPLE_ID_HEADER}\t{BARCODE_HEADER}")
     }
 }
 
 /// Struct for storing information about multiple samples and for defining functions associated
 /// with groups of [`Sample`]s, rather than individual structs.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SampleGroup {
     /// A group of samples
     pub samples: Vec<Sample>,
@@ -89,70 +99,404 @@ impl Display for SampleGroup {
 }
 
 impl SampleGroup {
-    /// Validates a group of [`Sample`]s and instantiates a [`Self`] struct if they are
-    /// valid. Will clone the [`Sample`] structs and change the number on the `ordinal` field on
-    /// those cloned to match the order in which they are stored in this [`Self`]
+    /// Validates a group of [`Sample`]s and instantiates a [`Self`] struct if they are valid. Will
+    /// clone the [`Sample`] structs and change the number on the `ordinal` field on those cloned
+    /// to match the order in which they are stored in this [`Self`].
+    ///
+    /// Per-sample read structures may differ in their per-input `(T, B, M, C)` segment counts
+    /// across samples (which lets each sample produce a different set of output files), but
+    /// the total length of all sample-barcode (`B`) segments per sample must equal the
+    /// `barcode` column for that sample (and barcodes are required to be the same length).
+    ///
     /// # Panics
-    ///   - Will panic if sample metadata sheet is improperly formatted
-    ///   - Will panic if there are duplicate sample names provided
-    ///   - Will panic if there are duplicate barcodes provided
-    ///   - Will panic if barcodes don't all have the same length
+    ///   - Will panic if sample metadata sheet is improperly formatted.
+    ///   - Will panic if there are duplicate sample names provided.
+    ///   - Will panic if there are duplicate barcodes provided.
+    ///   - Will panic if barcodes don't all have the same length.
+    ///   - Will panic if any sample's per-sample sample-barcode (`B`) segment lengths don't
+    ///     sum to that sample's `barcode` column length.
     #[must_use]
     pub fn from_samples(samples: &[Sample]) -> Self {
-        // Validate that we have at least one name
         assert!(!samples.is_empty(), "Must provide one or more sample");
 
-        // Validate that all the sample names are unique
         assert!(
             samples.iter().map(|s| &s.sample_id).all_unique(),
             "Each sample name must be unique, duplicate identified"
         );
 
-        // Validate that the barcodes are all unique
         assert!(
             samples.iter().map(|s| &s.barcode).all_unique(),
             "Each sample barcode must be unique, duplicate identified",
         );
 
-        // Validate that the barcodes are all of the same length
         let first_barcode_length = samples[0].barcode.len();
         assert!(
             samples.iter().map(|s| &s.barcode).all(|b| b.len() == first_barcode_length),
             "All barcodes must have the same length",
         );
 
+        // Per-sample read structures (when present) must have B-segments whose lengths sum to
+        // the sample's `barcode` column length.  Sample-barcode segments must be fixed-length.
+        for sample in samples {
+            let Some(rs) = sample.read_structures.as_ref() else { continue };
+            let b_len: usize = rs
+                .iter()
+                .flat_map(|r| r.segments_by_type(SegmentType::SampleBarcode))
+                .map(|seg| {
+                    seg.length.expect(
+                        "sample barcode segments in per-sample read structures must be fixed \
+                         length",
+                    )
+                })
+                .sum();
+            assert!(
+                b_len == sample.barcode.len(),
+                "Sample {}: total sample-barcode (B) length across per-sample read structures \
+                 is {} but barcode column has {} bases",
+                sample.sample_id,
+                b_len,
+                sample.barcode.len(),
+            );
+        }
+
         Self {
             samples: samples
                 .iter()
                 .enumerate()
                 .map(|(ordinal, sample)| {
-                    Sample::new(ordinal, sample.sample_id.clone(), sample.barcode.clone())
+                    Sample::with_read_structures(
+                        ordinal,
+                        sample.sample_id.clone(),
+                        sample.barcode.clone(),
+                        sample.read_structures.clone(),
+                    )
                 })
                 .collect(),
         }
     }
 
-    /// Attempts to load a [`Self`] object from a file. File should be delimeted with
-    /// `delimiter`, should have a header with `name` and `barcode` fields present.
+    /// Attempts to load a [`Self`] object from a tab-delimited file.  The file must have a header
+    /// row containing at least the columns `sample_id` and `barcode`.  Optional additional columns
+    /// `read_structure_1`, `read_structure_2`, ..., `read_structure_<N>` attach per-sample read
+    /// structures to each sample (one per input FASTQ in the order given to `--inputs`).  When
+    /// these columns are present:
+    ///
+    /// - `globals` (the `--read-structures` argument) must have exactly `N` entries, one per
+    ///   input FASTQ.
+    /// - A blank cell in `read_structure_<i>` falls back to `globals[i-1]` for that sample.
+    /// - A row whose `read_structure_<n>` cells are all blank uses `globals` entirely (i.e. is
+    ///   equivalent to omitting the per-sample columns for that sample only).
+    ///
+    /// When no `read_structure_<n>` columns are present, `globals` is unused and every sample
+    /// uses the global structures.
+    ///
     /// # Errors
-    ///   - Will error if file cannot be read, either due to not the file not existing or due to
-    ///     the format being different from the format expected.
+    ///   - Will error if the file cannot be read.
+    ///   - Will error if the header row is missing required columns.
+    ///   - Will error if `read_structure_<n>` columns are non-contiguous or don't match
+    ///     `globals.len()` (when present).
+    ///   - Will error if any `read_structure_<n>` cell has a value that fails to parse.
     /// # Panics
-    ///   - Will panic if sample metadata sheet is improperly formatted
-    ///   - Will panic if a different number of names and barcodes are provided
-    ///   - Will panic if each
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<SampleGroup, fgoxide::FgError> {
-        let reader = DelimFile::default();
-        Ok(Self::from_samples(&reader.read(path, DEFAULT_FILE_DELIMETER, false)?))
+    ///   - Will panic if [`SampleGroup::from_samples`] panics on the parsed records.
+    pub fn from_file<P: AsRef<Path>>(path: P, globals: &[ReadStructure]) -> Result<SampleGroup> {
+        let path = path.as_ref();
+        let io = Io::default();
+        let lines = io
+            .read_lines(path)
+            .with_context(|| format!("failed to read sample metadata file {path:?}"))?;
+        let mut iter = lines.into_iter().filter(|l| !l.trim().is_empty());
+
+        let header = iter.next().ok_or_else(|| {
+            anyhow!(
+                "sample metadata file {path:?} is empty (expected header line {})",
+                Sample::deserialize_header_line(),
+            )
+        })?;
+        // Strip a UTF-8 BOM and any trailing CR so files saved on Windows or with a BOM
+        // (e.g. by Excel/Notepad) parse correctly.
+        let header = strip_bom_and_cr(&header);
+        let header_fields: Vec<&str> = header.split(DEFAULT_FILE_DELIMETER as char).collect();
+
+        let sample_id_idx =
+            header_fields.iter().position(|c| *c == SAMPLE_ID_HEADER).ok_or_else(|| {
+                anyhow!("sample metadata header is missing column `{SAMPLE_ID_HEADER}`")
+            })?;
+        let barcode_idx =
+            header_fields.iter().position(|c| *c == BARCODE_HEADER).ok_or_else(|| {
+                anyhow!("sample metadata header is missing column `{BARCODE_HEADER}`")
+            })?;
+
+        // Discover read_structure_<n> columns in header order; require contiguous indexing
+        // starting at 1 and a total count matching `globals.len()` (when present).
+        let mut rs_columns: Vec<(usize, usize)> = Vec::new(); // (n, header_idx)
+        for (idx, name) in header_fields.iter().enumerate() {
+            if let Some(suffix) = name.strip_prefix(READ_STRUCTURE_PREFIX) {
+                let n: usize = suffix
+                    .parse()
+                    .with_context(|| format!("metadata column `{name}` has non-integer suffix"))?;
+                ensure!(n >= 1, "metadata column `{name}` must use 1-based indexing");
+                rs_columns.push((n, idx));
+            }
+        }
+        rs_columns.sort_by_key(|(n, _)| *n);
+        for (i, (n, _)) in rs_columns.iter().enumerate() {
+            ensure!(
+                *n == i + 1,
+                "per-sample read structure columns must be contiguous starting at \
+                 `{READ_STRUCTURE_PREFIX}1` (found `{READ_STRUCTURE_PREFIX}{n}` at position {})",
+                i + 1,
+            );
+        }
+        if !rs_columns.is_empty() {
+            ensure!(
+                rs_columns.len() == globals.len(),
+                "metadata file has {} `{READ_STRUCTURE_PREFIX}<n>` column(s) but \
+                 `--read-structures` has {} entry/entries",
+                rs_columns.len(),
+                globals.len(),
+            );
+        }
+
+        let mut samples: Vec<Sample> = Vec::new();
+        for (line_no, line) in iter.enumerate() {
+            let row_no = line_no + 2; // header is line 1
+            let line = line.trim_end_matches('\r');
+            let cols: Vec<&str> = line.split(DEFAULT_FILE_DELIMETER as char).collect();
+            ensure!(
+                cols.len() == header_fields.len(),
+                "sample metadata row {row_no} has {} columns but header has {}",
+                cols.len(),
+                header_fields.len(),
+            );
+            let sample_id = cols[sample_id_idx].to_owned();
+            let barcode = cols[barcode_idx].to_owned();
+            let read_structures =
+                parse_per_sample_read_structures(row_no, &cols, &rs_columns, globals)?;
+            samples.push(Sample::with_read_structures(
+                samples.len(),
+                sample_id,
+                barcode,
+                read_structures,
+            ));
+        }
+
+        if samples.is_empty() {
+            bail!("sample metadata file {path:?} contained no sample rows");
+        }
+        Ok(Self::from_samples(&samples))
     }
+
+    /// Returns true if this group has per-sample read structures (i.e. at least one sample
+    /// carries custom read structures that override `--read-structures`).
+    #[must_use]
+    pub fn has_per_sample_read_structures(&self) -> bool {
+        self.samples.iter().any(|s| s.read_structures.is_some())
+    }
+
+    /// Returns the per-input matching prefix lengths needed to demultiplex this sample group.
+    /// For each input FASTQ index, this is the maximum across samples of the number of bases
+    /// before the first Template segment in that sample's read structure.  Falls back to the
+    /// corresponding entry in `default_structures` for samples without per-sample read
+    /// structures.
+    ///
+    /// # Errors
+    ///   - Returns an error if any non-Template segment in the matching window has a
+    ///     non-fixed length.
+    ///   - Returns an error if a sample's per-sample read-structure count differs from
+    ///     `default_structures.len()`.
+    pub fn matching_prefix_lens(&self, default_structures: &[ReadStructure]) -> Result<Vec<usize>> {
+        let n = default_structures.len();
+        let mut maxes = vec![0usize; n];
+        for sample in &self.samples {
+            let rs_for_sample = sample.read_structures.as_deref().unwrap_or(default_structures);
+            ensure!(
+                rs_for_sample.len() == n,
+                "sample {}: number of read structures ({}) does not match number of inputs ({})",
+                sample.sample_id,
+                rs_for_sample.len(),
+                n,
+            );
+            for (i, rs) in rs_for_sample.iter().enumerate() {
+                let plen = pre_template_fixed_len(rs)
+                    .with_context(|| format!("sample {} input {}", sample.sample_id, i + 1))?;
+                if plen > maxes[i] {
+                    maxes[i] = plen;
+                }
+            }
+        }
+        Ok(maxes)
+    }
+
+    /// Builds the matching pattern bytes for each sample.  The pattern is a fixed-length
+    /// byte sequence (concatenated across all input FASTQs) of total length
+    /// `prefix_lens.iter().sum()`.  For each input, the sample's read structure is walked
+    /// position-by-position; B (sample-barcode) segment positions are filled from
+    /// `sample.barcode` (taken in order across inputs), and M/S/C/T segment positions and any
+    /// trailing positions up to the prefix length are filled with `N` (treated as a wildcard
+    /// by the matcher).
+    ///
+    /// # Errors
+    ///   - Returns an error if any sample's read structure has a non-fixed-length non-template
+    ///     segment in the matching window.
+    ///   - Returns an error if a sample-barcode (`B`) segment crosses the matching window
+    ///     boundary, since silently truncating a barcode would corrupt matching.
+    pub fn build_matching_patterns(
+        &self,
+        default_structures: &[ReadStructure],
+        prefix_lens: &[usize],
+    ) -> Result<Vec<Vec<u8>>> {
+        ensure!(
+            default_structures.len() == prefix_lens.len(),
+            "expected one prefix length per input FASTQ"
+        );
+        let total_len: usize = prefix_lens.iter().sum();
+        let mut patterns = Vec::with_capacity(self.samples.len());
+        for sample in &self.samples {
+            let rs_for_sample = sample.read_structures.as_deref().unwrap_or(default_structures);
+            ensure!(
+                rs_for_sample.len() == prefix_lens.len(),
+                "sample {}: number of read structures ({}) does not match number of inputs ({})",
+                sample.sample_id,
+                rs_for_sample.len(),
+                prefix_lens.len(),
+            );
+            let mut pattern = Vec::with_capacity(total_len);
+            let mut barcode_cursor = 0usize;
+            let barcode_bytes = sample.barcode.as_bytes();
+            for (rs, &prefix_len) in rs_for_sample.iter().zip(prefix_lens) {
+                let mut filled = 0usize;
+                for seg in rs.iter() {
+                    if seg.kind == SegmentType::Template {
+                        break;
+                    }
+                    let len = seg.length.ok_or_else(|| {
+                        anyhow!(
+                            "sample {}: non-template segment {seg} in read structure must have a \
+                             fixed length",
+                            sample.sample_id,
+                        )
+                    })?;
+                    let remaining = prefix_len - filled;
+                    let take = len.min(remaining);
+                    if seg.kind == SegmentType::SampleBarcode {
+                        ensure!(
+                            take == len,
+                            "sample {}: sample-barcode segment {seg} crosses the matching \
+                             window boundary (segment length {}, but only {} bases remain in \
+                             the {}-base window)",
+                            sample.sample_id,
+                            len,
+                            remaining,
+                            prefix_len,
+                        );
+                        pattern.extend_from_slice(
+                            &barcode_bytes[barcode_cursor..barcode_cursor + len],
+                        );
+                        barcode_cursor += len;
+                    } else {
+                        pattern.extend(std::iter::repeat_n(b'N', take));
+                    }
+                    filled += take;
+                    if take < len {
+                        break;
+                    }
+                }
+                if filled < prefix_len {
+                    pattern.extend(std::iter::repeat_n(b'N', prefix_len - filled));
+                }
+            }
+            ensure!(
+                barcode_cursor == sample.barcode.len(),
+                "sample {}: only consumed {} of {} barcode bases when building matching pattern",
+                sample.sample_id,
+                barcode_cursor,
+                sample.barcode.len(),
+            );
+            patterns.push(pattern);
+        }
+        Ok(patterns)
+    }
+}
+
+/// Resolves the per-sample read structure cells for one row of the metadata file.  Returns
+/// `None` if `rs_columns` is empty or every cell is blank (sample uses globals entirely);
+/// otherwise returns `Some(vec)` with each blank cell replaced by `globals[i]`.
+///
+/// Sample-barcode (`B`) segments in any parsed cell must be fixed length: a variable-length
+/// `+B` is rejected here so the error surfaces as a normal `Result` rather than panicking
+/// later during `from_samples` validation.
+fn parse_per_sample_read_structures(
+    row_no: usize,
+    cols: &[&str],
+    rs_columns: &[(usize, usize)],
+    globals: &[ReadStructure],
+) -> Result<Option<Vec<ReadStructure>>> {
+    if rs_columns.is_empty() {
+        return Ok(None);
+    }
+    let mut entries: Vec<Option<ReadStructure>> = Vec::with_capacity(rs_columns.len());
+    for (n, idx) in rs_columns {
+        let raw = cols[*idx].trim();
+        if raw.is_empty() {
+            entries.push(None);
+        } else {
+            let rs = ReadStructure::from_str(raw).with_context(|| {
+                format!(
+                    "sample metadata row {row_no} column `{READ_STRUCTURE_PREFIX}{n}` has \
+                     invalid read structure `{raw}`",
+                )
+            })?;
+            for seg in rs.segments_by_type(SegmentType::SampleBarcode) {
+                ensure!(
+                    seg.length.is_some(),
+                    "sample metadata row {row_no} column `{READ_STRUCTURE_PREFIX}{n}`: \
+                     sample-barcode segment {seg} must be fixed length (variable-length `+B` \
+                     is not supported in per-sample read structures)",
+                );
+            }
+            entries.push(Some(rs));
+        }
+    }
+    if entries.iter().all(Option::is_none) {
+        return Ok(None);
+    }
+    let resolved: Vec<ReadStructure> = entries
+        .into_iter()
+        .enumerate()
+        .map(|(i, e)| e.unwrap_or_else(|| globals[i].clone()))
+        .collect();
+    Ok(Some(resolved))
+}
+
+/// Strips a leading UTF-8 byte-order mark and any trailing carriage return from a line so that
+/// files saved with a BOM or CRLF line endings parse correctly.
+fn strip_bom_and_cr(s: &str) -> &str {
+    s.strip_prefix('\u{FEFF}').unwrap_or(s).trim_end_matches('\r')
+}
+
+/// Returns the offset of the first Template segment in a read structure.  If the read structure
+/// has no Template segments, returns the sum of all (fixed-length) segment lengths.
+///
+/// # Errors
+///   - Returns an error if a non-Template segment lacks a fixed length.
+fn pre_template_fixed_len(rs: &ReadStructure) -> Result<usize> {
+    let mut len = 0;
+    for seg in rs.iter() {
+        if seg.kind == SegmentType::Template {
+            return Ok(len);
+        }
+        len += seg.length.ok_or_else(|| {
+            anyhow!("non-template segment {seg} in read structure {rs} must have a fixed length")
+        })?;
+    }
+    Ok(len)
 }
 
 #[cfg(test)]
 mod tests {
-    use core::panic;
-
     use super::*;
-    use fgoxide::{self, io::Io};
+    use fgoxide::io::Io;
+    use std::str::FromStr;
     use tempfile::TempDir;
 
     // ############################################################################################
@@ -170,12 +514,13 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        let samples_metadata = SampleGroup::from_file(&f1).unwrap();
+        let samples_metadata = SampleGroup::from_file(&f1, &[]).unwrap();
 
         assert!(samples_metadata.samples[0].sample_id == "sample1");
         assert!(samples_metadata.samples[1].sample_id == "sample2");
         assert!(samples_metadata.samples[0].barcode == "GATTACA");
         assert!(samples_metadata.samples[1].barcode == "CATGCTA");
+        assert!(!samples_metadata.has_per_sample_read_structures());
     }
 
     #[test]
@@ -192,7 +537,7 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        let samples_metadata = SampleGroup::from_file(&f1).unwrap();
+        let samples_metadata = SampleGroup::from_file(&f1, &[]).unwrap();
 
         assert!(samples_metadata.samples[0].sample_id == "sample1");
         assert!(samples_metadata.samples[1].sample_id == "sample2");
@@ -219,18 +564,13 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        let err = SampleGroup::from_file(&f1).unwrap_err();
-
-        if let fgoxide::FgError::DelimFileHeaderError { expected, found } = err {
-            assert_eq!(expected, Sample::deserialize_header_line());
-            assert_eq!(found, "sample_id,barcode");
-        } else {
-            panic!()
-        }
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("missing column `sample_id`"), "got: {msg}");
     }
 
     // ############################################################################################
-    // Test [`SampleGroup::from_file`] - Expected to panic
+    // Test [`SampleGroup::from_file`] - Expected to error or panic
     // ############################################################################################
     #[test]
     fn test_reading_from_file_with_no_header() {
@@ -240,18 +580,12 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        if let fgoxide::FgError::DelimFileHeaderError { expected, found } =
-            SampleGroup::from_file(&f1).unwrap_err()
-        {
-            assert_eq!(expected, Sample::deserialize_header_line());
-            assert_eq!(found, "sample1\tGATTACA");
-        } else {
-            panic!("Different error type than expected reading from headerless file.")
-        }
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("missing column `sample_id`"), "got: {msg}");
     }
 
     #[test]
-    #[should_panic(expected = "Must provide one or more sample")]
     fn test_reading_header_only_file() {
         let lines = vec![Sample::deserialize_header_line()];
         let tempdir = TempDir::new().unwrap();
@@ -259,11 +593,12 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        let _sm = SampleGroup::from_file(&f1).unwrap();
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("contained no sample rows"), "got: {msg}");
     }
 
     #[test]
-    #[should_panic(expected = "Must provide one or more sample")]
     fn test_reading_empty_file() {
         let lines = vec![""];
         let tempdir = TempDir::new().unwrap();
@@ -271,18 +606,18 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        let _sm = SampleGroup::from_file(&f1).unwrap();
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("is empty") || msg.contains("missing column"), "got: {msg}");
     }
 
     #[test]
     fn test_reading_non_existent_file() {
         let tempdir = TempDir::new().unwrap();
         let f1 = tempdir.path().join("sample_metadata.tsv");
-        if let fgoxide::FgError::IoError(e) = SampleGroup::from_file(&f1).unwrap_err() {
-            assert_eq!(e.to_string(), "No such file or directory (os error 2)");
-        } else {
-            panic!("Different error than expected reading non-existent file")
-        }
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("failed to read sample metadata file"), "got: {msg}");
     }
 
     // ############################################################################################
@@ -295,7 +630,7 @@ mod tests {
         let ordinal = 0;
         let sample = Sample::new(ordinal, name.clone(), barcode.clone());
         assert_eq!(
-            Sample { sample_id: name, barcode, ordinal },
+            Sample { sample_id: name, barcode, read_structures: None, ordinal },
             sample,
             "Sample differed from expectation"
         );
@@ -304,7 +639,6 @@ mod tests {
     // ############################################################################################
     // Test [`Sample::new`] - Expected to panic
     // ############################################################################################
-
     #[test]
     #[should_panic(expected = "Sample name cannot be empty")]
     fn test_new_sample_fail1_empty_sample_name() {
@@ -394,5 +728,307 @@ mod tests {
             Sample::new(0, "sample_2".to_owned(), "CATGGA".to_owned()),
         ];
         let _sample_group = SampleGroup::from_samples(&samples);
+    }
+
+    // ############################################################################################
+    // Tests for per-sample read structures.
+    // ############################################################################################
+    fn make_rs(s: &str) -> ReadStructure {
+        ReadStructure::from_str(s).unwrap()
+    }
+
+    fn sample_with_rs(name: &str, barcode: &str, structures: &[&str]) -> Sample {
+        let rs = structures.iter().map(|s| make_rs(s)).collect();
+        Sample::with_read_structures(0, name.to_owned(), barcode.to_owned(), Some(rs))
+    }
+
+    fn write_metadata(tempdir: &TempDir, lines: &[String]) -> std::path::PathBuf {
+        let f1 = tempdir.path().join("metadata.tsv");
+        Io::default().write_lines(&f1, lines).unwrap();
+        f1
+    }
+
+    #[test]
+    fn test_per_sample_read_structures_round_trip_via_metadata() {
+        // Two-input case: each input contributes 7B, so the barcode column carries 14 bases.
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_1\tread_structure_2".to_owned(),
+            "S1\tGATTACAACGTACG\t3M7B1S+T\t3M7B1S+T".to_owned(),
+            "S2\tGGGGGGGTTTTTTT\t3M1S7B1S+T\t3M1S7B1S+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M9B+T"), make_rs("9B+T")];
+        let group = SampleGroup::from_file(&f1, &globals).unwrap();
+        assert!(group.has_per_sample_read_structures());
+        let s1_rs = group.samples[0].read_structures.as_ref().unwrap();
+        assert_eq!(s1_rs.len(), 2);
+        let s2_rs = group.samples[1].read_structures.as_ref().unwrap();
+        assert_eq!(s2_rs.len(), 2);
+    }
+
+    /// Per-sample read structures may have differing per-input `(T, B, M, C)` segment counts
+    /// across samples, as long as each sample's B-segment lengths sum to its `barcode` column.
+    #[test]
+    fn test_per_sample_read_structures_signatures_may_differ_across_samples() {
+        // S1 has one B-segment of length 14; S2 has two B-segments (7+7) of total length 14.
+        let s1 = sample_with_rs("S1", "GATTACAACGTACG", &["3M14B+T"]);
+        let s2 = sample_with_rs("S2", "TTTTTTTGGGGGGG", &["3M7B7B+T"]);
+        let group = SampleGroup::from_samples(&[s1, s2]);
+        assert!(group.has_per_sample_read_structures());
+    }
+
+    /// Mixed mode: some samples have per-sample read structures, others fall back to globals.
+    #[test]
+    fn test_per_sample_read_structures_mixed_with_global_only_samples() {
+        let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
+        let s2 = Sample::new(0, "S2".to_owned(), "CCCCCCC".to_owned());
+        let group = SampleGroup::from_samples(&[s1, s2]);
+        assert!(group.has_per_sample_read_structures());
+        assert!(group.samples[0].read_structures.is_some());
+        assert!(group.samples[1].read_structures.is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "barcode column has")]
+    fn test_per_sample_read_structures_barcode_length_mismatch() {
+        // S1 declares 7B + 7B = 14 bases of barcode but provides only 7 in the column.
+        let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T", "3M7B1S+T"]);
+        let _ = SampleGroup::from_samples(&[s1]);
+    }
+
+    #[test]
+    fn test_matching_prefix_lens_uses_max_across_samples() {
+        // S1 prefix per input: 3+7+1 = 11; S2 prefix: 3+1+7+1 = 12
+        let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
+        let s2 = sample_with_rs("S2", "GGGGGGG", &["3M1S7B1S+T"]);
+        let group = SampleGroup::from_samples(&[s1, s2]);
+        let defaults = vec![make_rs("3M9B+T")];
+        let lens = group.matching_prefix_lens(&defaults).unwrap();
+        assert_eq!(lens, vec![12]);
+    }
+
+    #[test]
+    fn test_build_matching_patterns_codec_two_samples() {
+        let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
+        let s2 = sample_with_rs("S2", "GGGGGGG", &["3M1S7B1S+T"]);
+        let group = SampleGroup::from_samples(&[s1, s2]);
+        let defaults = vec![make_rs("3M9B+T")];
+        let lens = group.matching_prefix_lens(&defaults).unwrap();
+        let patterns = group.build_matching_patterns(&defaults, &lens).unwrap();
+        // Total length is 12 for each pattern.
+        // S1: NNN + GATTACA + N (S=skip wildcarded) + N (padding to 12)
+        assert_eq!(patterns[0], b"NNNGATTACANN");
+        // S2: NNN + N (S=stagger wildcarded) + GGGGGGG + N (S=trailing wildcarded)
+        assert_eq!(patterns[1], b"NNNNGGGGGGGN");
+    }
+
+    #[test]
+    fn test_build_matching_patterns_falls_back_to_defaults_when_no_per_sample() {
+        let s1 = Sample::new(0, "S1".to_owned(), "GATTACA".to_owned());
+        let group = SampleGroup::from_samples(&[s1]);
+        let defaults = vec![make_rs("3M7B1S+T")];
+        let lens = group.matching_prefix_lens(&defaults).unwrap();
+        assert_eq!(lens, vec![11]);
+        let patterns = group.build_matching_patterns(&defaults, &lens).unwrap();
+        assert_eq!(patterns[0], b"NNNGATTACAN");
+    }
+
+    #[test]
+    fn test_build_matching_patterns_dual_input_concatenated() {
+        // Two inputs, each with its own staggered structure; barcode column concatenates the
+        // two B-segments left-to-right across inputs.
+        let s1 = sample_with_rs("S1", "GATTACAACGTACG", &["3M7B1S+T", "7B+T"]);
+        let s2 = sample_with_rs("S2", "GGGGGGGTTTTTTT", &["3M1S7B1S+T", "1S7B+T"]);
+        let group = SampleGroup::from_samples(&[s1, s2]);
+        let defaults = vec![make_rs("3M9B+T"), make_rs("9B+T")];
+        let lens = group.matching_prefix_lens(&defaults).unwrap();
+        // Input 1: max(11, 12) = 12; Input 2: max(7, 8) = 8.
+        assert_eq!(lens, vec![12, 8]);
+        let patterns = group.build_matching_patterns(&defaults, &lens).unwrap();
+        // Total pattern length: 12 + 8 = 20.
+        let mut expected_s1 = b"NNNGATTACANN".to_vec();
+        expected_s1.extend_from_slice(b"ACGTACGN");
+        assert_eq!(patterns[0], expected_s1);
+        let mut expected_s2 = b"NNNNGGGGGGGN".to_vec();
+        expected_s2.extend_from_slice(b"NTTTTTTT");
+        assert_eq!(patterns[1], expected_s2);
+    }
+
+    /// A sample-barcode segment crossing the matching window is rejected with a clear error
+    /// rather than silently truncated.
+    #[test]
+    fn test_build_matching_patterns_b_segment_crossing_window_errors() {
+        let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
+        let group = SampleGroup::from_samples(&[s1]);
+        let defaults = vec![make_rs("3M7B1S+T")];
+        let lens = vec![5usize]; // forced narrow window for the test
+        let err = group.build_matching_patterns(&defaults, &lens).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("crosses the matching window boundary"), "got: {msg}");
+    }
+
+    // ############################################################################################
+    // Per-cell fallback tests for `from_file`.
+    // ############################################################################################
+    /// A blank `read_structure_<n>` cell falls back to `globals[n-1]` for that sample.
+    #[test]
+    fn test_per_cell_fallback_uses_globals_for_blank_cells() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_1\tread_structure_2".to_owned(),
+            // S1 overrides only input 1; input 2 is blank → uses globals[1].
+            "S1\tGATTACAGGGGGGG\t3M7B1S+T\t".to_owned(),
+            // S2 overrides only input 2; input 1 is blank → uses globals[0].
+            "S2\tCCCCCCCAAAAAAA\t\t1S7B+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T"), make_rs("7B+T")];
+        let group = SampleGroup::from_file(&f1, &globals).unwrap();
+        let s1_rs = group.samples[0].read_structures.as_ref().unwrap();
+        assert_eq!(s1_rs.len(), 2);
+        assert_eq!(s1_rs[0].to_string(), "3M7B1S+T");
+        assert_eq!(s1_rs[1].to_string(), "7B+T");
+        let s2_rs = group.samples[1].read_structures.as_ref().unwrap();
+        assert_eq!(s2_rs[0].to_string(), "3M7B+T");
+        assert_eq!(s2_rs[1].to_string(), "1S7B+T");
+    }
+
+    /// A row whose `read_structure_<n>` cells are all blank uses globals entirely (the
+    /// sample's stored `read_structures` is `None`).
+    #[test]
+    fn test_per_cell_all_blank_row_falls_back_to_globals_entirely() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_1\tread_structure_2".to_owned(),
+            "S1\tGATTACAGGGGGGG\t3M7B1S+T\t3M7B1S+T".to_owned(),
+            "S2\tCCCCCCCAAAAAAA\t\t".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T"), make_rs("3M7B+T")];
+        let group = SampleGroup::from_file(&f1, &globals).unwrap();
+        assert!(group.samples[0].read_structures.is_some());
+        assert!(group.samples[1].read_structures.is_none());
+    }
+
+    /// `read_structure_<n>` column count must match `globals.len()` when columns are present.
+    #[test]
+    fn test_per_sample_column_count_must_match_globals() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_1".to_owned(),
+            "S1\tGATTACA\t3M7B1S+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T"), make_rs("100T")];
+        let err = SampleGroup::from_file(&f1, &globals).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("`read_structure_<n>` column(s)") && msg.contains("--read-structures"),
+            "got: {msg}",
+        );
+    }
+
+    /// A variable-length sample-barcode (`+B`) in a per-sample column must surface as a
+    /// normal `Result` error rather than panic during downstream validation.
+    #[test]
+    fn test_per_sample_variable_length_b_segment_errors() {
+        let lines =
+            vec!["sample_id\tbarcode\tread_structure_1".to_owned(), "S1\tGATTACA\t3M+B".to_owned()];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T")];
+        let err = SampleGroup::from_file(&f1, &globals).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("must be fixed length"), "got: {msg}");
+    }
+
+    /// A UTF-8 BOM on the first header field should not cause a confusing
+    /// "missing column `sample_id`" error.
+    #[test]
+    fn test_header_with_utf8_bom_is_handled() {
+        let lines = vec![
+            format!("\u{FEFF}{}", Sample::deserialize_header_line()),
+            "sample1\tGATTACA".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let group = SampleGroup::from_file(&f1, &[]).unwrap();
+        assert_eq!(group.samples[0].sample_id, "sample1");
+        assert_eq!(group.samples[0].barcode, "GATTACA");
+    }
+
+    /// CRLF line endings on a row should not cause the trailing `\r` to bleed into the
+    /// barcode column and break downstream validation.
+    #[test]
+    fn test_rows_with_crlf_endings_are_handled() {
+        let header = format!("{}\r", Sample::deserialize_header_line());
+        let lines = vec![header, "sample1\tGATTACA\r".to_owned(), "sample2\tCATGCTA\r".to_owned()];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let group = SampleGroup::from_file(&f1, &[]).unwrap();
+        assert_eq!(group.samples[0].barcode, "GATTACA");
+        assert_eq!(group.samples[1].barcode, "CATGCTA");
+    }
+
+    /// `matching_prefix_lens` must error (not panic) when a sample's per-sample read
+    /// structure count differs from `default_structures.len()`.
+    #[test]
+    fn test_matching_prefix_lens_errors_on_rs_count_mismatch() {
+        // Sample declares two read structures; defaults provide only one.
+        let s1 = sample_with_rs("S1", "GATTACAGGGGGGG", &["3M7B1S+T", "7B+T"]);
+        let group = SampleGroup::from_samples(&[s1]);
+        let defaults = vec![make_rs("3M7B+T")];
+        let err = group.matching_prefix_lens(&defaults).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("number of read structures") && msg.contains("number of inputs"),
+            "got: {msg}",
+        );
+    }
+
+    /// Non-contiguous `read_structure_<n>` columns must error.
+    #[test]
+    fn test_per_sample_columns_must_be_contiguous() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_1\tread_structure_3".to_owned(),
+            "S1\tGATTACA\t3M7B1S+T\t1S7B+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T"), make_rs("7B+T")];
+        let err = SampleGroup::from_file(&f1, &globals).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("contiguous"), "got: {msg}");
+    }
+
+    /// A non-integer suffix on a `read_structure_<n>` column must error.
+    #[test]
+    fn test_per_sample_columns_must_have_integer_suffix() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_abc".to_owned(),
+            "S1\tGATTACA\t3M7B1S+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T")];
+        let err = SampleGroup::from_file(&f1, &globals).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("non-integer suffix"), "got: {msg}");
+    }
+
+    /// A zero-indexed `read_structure_0` column must error since indexing is 1-based.
+    #[test]
+    fn test_per_sample_columns_must_be_one_indexed() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_0".to_owned(),
+            "S1\tGATTACA\t3M7B1S+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T")];
+        let err = SampleGroup::from_file(&f1, &globals).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("1-based indexing"), "got: {msg}");
     }
 }

--- a/src/lib/samples.rs
+++ b/src/lib/samples.rs
@@ -108,29 +108,29 @@ impl SampleGroup {
     /// the total length of all sample-barcode (`B`) segments per sample must equal the
     /// `barcode` column for that sample (and barcodes are required to be the same length).
     ///
-    /// # Panics
-    ///   - Will panic if sample metadata sheet is improperly formatted.
-    ///   - Will panic if there are duplicate sample names provided.
-    ///   - Will panic if there are duplicate barcodes provided.
-    ///   - Will panic if barcodes don't all have the same length.
-    ///   - Will panic if any sample's per-sample sample-barcode (`B`) segment lengths don't
+    /// # Errors
+    ///   - Will error if no samples are provided.
+    ///   - Will error if there are duplicate sample names provided.
+    ///   - Will error if there are duplicate barcodes provided.
+    ///   - Will error if barcodes don't all have the same length.
+    ///   - Will error if any sample's per-sample sample-barcode (`B`) segment is not fixed length.
+    ///   - Will error if any sample's per-sample sample-barcode (`B`) segment lengths don't
     ///     sum to that sample's `barcode` column length.
-    #[must_use]
-    pub fn from_samples(samples: &[Sample]) -> Self {
-        assert!(!samples.is_empty(), "Must provide one or more sample");
+    pub fn from_samples(samples: &[Sample]) -> Result<Self> {
+        ensure!(!samples.is_empty(), "Must provide one or more sample");
 
-        assert!(
+        ensure!(
             samples.iter().map(|s| &s.sample_id).all_unique(),
             "Each sample name must be unique, duplicate identified"
         );
 
-        assert!(
+        ensure!(
             samples.iter().map(|s| &s.barcode).all_unique(),
             "Each sample barcode must be unique, duplicate identified",
         );
 
         let first_barcode_length = samples[0].barcode.len();
-        assert!(
+        ensure!(
             samples.iter().map(|s| &s.barcode).all(|b| b.len() == first_barcode_length),
             "All barcodes must have the same length",
         );
@@ -139,17 +139,18 @@ impl SampleGroup {
         // the sample's `barcode` column length.  Sample-barcode segments must be fixed-length.
         for sample in samples {
             let Some(rs) = sample.read_structures.as_ref() else { continue };
-            let b_len: usize = rs
-                .iter()
-                .flat_map(|r| r.segments_by_type(SegmentType::SampleBarcode))
-                .map(|seg| {
-                    seg.length.expect(
-                        "sample barcode segments in per-sample read structures must be fixed \
-                         length",
+            let mut b_len: usize = 0;
+            for seg in rs.iter().flat_map(|r| r.segments_by_type(SegmentType::SampleBarcode)) {
+                let len = seg.length.ok_or_else(|| {
+                    anyhow!(
+                        "Sample {}: sample-barcode (B) segments in per-sample read structures \
+                         must be fixed length",
+                        sample.sample_id,
                     )
-                })
-                .sum();
-            assert!(
+                })?;
+                b_len += len;
+            }
+            ensure!(
                 b_len == sample.barcode.len(),
                 "Sample {}: total sample-barcode (B) length across per-sample read structures \
                  is {} but barcode column has {} bases",
@@ -159,7 +160,7 @@ impl SampleGroup {
             );
         }
 
-        Self {
+        Ok(Self {
             samples: samples
                 .iter()
                 .enumerate()
@@ -172,7 +173,7 @@ impl SampleGroup {
                     )
                 })
                 .collect(),
-        }
+        })
     }
 
     /// Attempts to load a [`Self`] object from a tab-delimited file.  The file must have a header
@@ -196,8 +197,8 @@ impl SampleGroup {
     ///   - Will error if `read_structure_<n>` columns are non-contiguous or don't match
     ///     `globals.len()` (when present).
     ///   - Will error if any `read_structure_<n>` cell has a value that fails to parse.
-    /// # Panics
-    ///   - Will panic if [`SampleGroup::from_samples`] panics on the parsed records.
+    ///   - Will error if [`SampleGroup::from_samples`] rejects the parsed records (e.g. duplicate
+    ///     names/barcodes, inconsistent barcode lengths, or barcode/`B`-segment length mismatch).
     pub fn from_file<P: AsRef<Path>>(path: P, globals: &[ReadStructure]) -> Result<SampleGroup> {
         let path = path.as_ref();
         let io = Io::default();
@@ -283,7 +284,7 @@ impl SampleGroup {
         if samples.is_empty() {
             bail!("sample metadata file {path:?} contained no sample rows");
         }
-        Ok(Self::from_samples(&samples))
+        Self::from_samples(&samples)
     }
 
     /// Returns true if this group has per-sample read structures (i.e. at least one sample
@@ -317,8 +318,21 @@ impl SampleGroup {
                 n,
             );
             for (i, rs) in rs_for_sample.iter().enumerate() {
-                let plen = pre_template_fixed_len(rs)
-                    .with_context(|| format!("sample {} input {}", sample.sample_id, i + 1))?;
+                let plen = pre_template_fixed_len(rs).with_context(|| {
+                    let source = if sample.read_structures.is_some() {
+                        format!("sample {}'s `read_structure_{}`", sample.sample_id, i + 1)
+                    } else {
+                        format!(
+                            "the `--read-structures` fallback for sample {} (input {})",
+                            sample.sample_id,
+                            i + 1,
+                        )
+                    };
+                    format!(
+                        "per-sample demultiplexing requires a fixed-length matching window, so \
+                         every segment before the template in {source} must have a fixed length"
+                    )
+                })?;
                 if plen > maxes[i] {
                     maxes[i] = plen;
                 }
@@ -360,6 +374,50 @@ impl SampleGroup {
                 rs_for_sample.len(),
                 prefix_lens.len(),
             );
+
+            // All sample-barcode (B) segments must precede the template (T): a B positioned after
+            // the template falls outside the matching window and can never be used to assign the
+            // read, so reject it explicitly rather than failing later with a confusing count.
+            for (input_idx, rs) in rs_for_sample.iter().enumerate() {
+                let total_b = rs.segments_by_type(SegmentType::SampleBarcode).count();
+                let b_before_template = rs
+                    .iter()
+                    .take_while(|seg| seg.kind != SegmentType::Template)
+                    .filter(|seg| seg.kind == SegmentType::SampleBarcode)
+                    .count();
+                ensure!(
+                    total_b == b_before_template,
+                    "sample {}: all sample-barcode (B) segments must precede the template (T) in \
+                     read structure {} (input {})",
+                    sample.sample_id,
+                    rs,
+                    input_idx + 1,
+                );
+            }
+
+            // The effective read structures' total sample-barcode (B) length must equal the
+            // barcode column length.  This also validates global-only samples in mixed mode, whose
+            // effective structure is the `--read-structures` fallback (a case `from_samples` cannot
+            // check because it has no access to the global structures).
+            let expected_barcode_len: usize = rs_for_sample
+                .iter()
+                .flat_map(|rs| rs.segments_by_type(SegmentType::SampleBarcode))
+                .map(|seg| seg.length.unwrap_or(0))
+                .sum();
+            ensure!(
+                expected_barcode_len == sample.barcode.len(),
+                "sample {}: {}read structure(s) declare {} sample-barcode (B) base(s) but the \
+                 barcode column has {} base(s)",
+                sample.sample_id,
+                if sample.read_structures.is_none() {
+                    "(using --read-structures fallback) "
+                } else {
+                    ""
+                },
+                expected_barcode_len,
+                sample.barcode.len(),
+            );
+
             let mut pattern = Vec::with_capacity(total_len);
             let mut barcode_cursor = 0usize;
             let barcode_bytes = sample.barcode.as_bytes();
@@ -619,6 +677,20 @@ mod tests {
     }
 
     #[test]
+    fn test_reading_from_file_with_duplicate_barcodes_errors() {
+        // A malformed user TSV (duplicate barcodes) must return a clean error, not panic.
+        let lines = vec!["sample_id\tbarcode", "sample1\tGATTACA", "sample2\tGATTACA"];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = tempdir.path().join("sample_metadata.tsv");
+
+        let io = Io::default();
+        io.write_lines(&f1, &lines).unwrap();
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Each sample barcode must be unique"), "got: {msg}");
+    }
+
+    #[test]
     fn test_reading_non_existent_file() {
         let tempdir = TempDir::new().unwrap();
         let f1 = tempdir.path().join("sample_metadata.tsv");
@@ -671,7 +743,7 @@ mod tests {
     fn test_from_samples_sample_group_pass1_single_sample() {
         let sample1 = Sample::new(0, "sample_1".to_owned(), "GATTACA".to_owned());
         let samples_vec = vec![sample1.clone()];
-        let sample_group = SampleGroup::from_samples(&samples_vec);
+        let sample_group = SampleGroup::from_samples(&samples_vec).unwrap();
 
         assert_eq!(sample_group, SampleGroup { samples: vec![sample1] });
     }
@@ -681,7 +753,7 @@ mod tests {
         let sample1 = Sample::new(0, "sample_1".to_owned(), "GATTACA".to_owned());
         let sample2 = Sample::new(1, "sample_2".to_owned(), "CATGGAT".to_owned());
         let samples_vec = vec![sample1.clone(), sample2.clone()];
-        let sample_group = SampleGroup::from_samples(&samples_vec);
+        let sample_group = SampleGroup::from_samples(&samples_vec).unwrap();
 
         assert_eq!(sample_group, SampleGroup { samples: vec![sample1, sample2] });
     }
@@ -692,49 +764,55 @@ mod tests {
         let sample2_before = Sample::new(2, "sample_2".to_owned(), "CATGGAT".to_owned());
         let sample2_after = Sample::new(1, "sample_2".to_owned(), "CATGGAT".to_owned());
         let samples_vec = vec![sample1.clone(), sample2_before];
-        let sample_group = SampleGroup::from_samples(&samples_vec);
+        let sample_group = SampleGroup::from_samples(&samples_vec).unwrap();
 
         assert_eq!(sample_group, SampleGroup { samples: vec![sample1, sample2_after] });
     }
 
     // ############################################################################################
-    // Test [`SampleGroup::from_samples`] - expected to panic
+    // Test [`SampleGroup::from_samples`] - expected to error
     // ############################################################################################
     #[test]
-    #[should_panic(expected = "Must provide one or more sample")]
     fn test_from_samples_sample_group_fail1_no_samples() {
         let samples = vec![];
-        let _sample_group = SampleGroup::from_samples(&samples);
+        let err = SampleGroup::from_samples(&samples).unwrap_err();
+        assert!(err.to_string().contains("Must provide one or more sample"), "got: {err:#}");
     }
 
     #[test]
-    #[should_panic(expected = "Each sample name must be unique, duplicate identified")]
-    fn test_from_samples_sample_group_fail2_duplicate_barcodes() {
+    fn test_from_samples_sample_group_fail2_duplicate_sample_names() {
         let samples = vec![
             Sample::new(0, "sample_1".to_owned(), "GATTACA".to_owned()),
             Sample::new(0, "sample_1".to_owned(), "CATGGAT".to_owned()),
         ];
-        let _sample_group = SampleGroup::from_samples(&samples);
+        let err = SampleGroup::from_samples(&samples).unwrap_err();
+        assert!(
+            err.to_string().contains("Each sample name must be unique, duplicate identified"),
+            "got: {err:#}",
+        );
     }
 
     #[test]
-    #[should_panic(expected = "Each sample barcode must be unique, duplicate identified")]
-    fn test_from_samples_sample_group_fail3_duplicate_sample_names() {
+    fn test_from_samples_sample_group_fail3_duplicate_barcodes() {
         let samples = vec![
             Sample::new(0, "sample_1".to_owned(), "GATTACA".to_owned()),
             Sample::new(0, "sample_2".to_owned(), "GATTACA".to_owned()),
         ];
-        let _sample_group = SampleGroup::from_samples(&samples);
+        let err = SampleGroup::from_samples(&samples).unwrap_err();
+        assert!(
+            err.to_string().contains("Each sample barcode must be unique, duplicate identified"),
+            "got: {err:#}",
+        );
     }
 
     #[test]
-    #[should_panic(expected = "All barcodes must have the same length")]
     fn test_from_samples_sample_group_fail4_barcodes_of_different_lengths() {
         let samples = vec![
             Sample::new(0, "sample_1".to_owned(), "GATTACA".to_owned()),
             Sample::new(0, "sample_2".to_owned(), "CATGGA".to_owned()),
         ];
-        let _sample_group = SampleGroup::from_samples(&samples);
+        let err = SampleGroup::from_samples(&samples).unwrap_err();
+        assert!(err.to_string().contains("All barcodes must have the same length"), "got: {err:#}");
     }
 
     // ############################################################################################
@@ -781,7 +859,7 @@ mod tests {
         // S1 has one B-segment of length 14; S2 has two B-segments (7+7) of total length 14.
         let s1 = sample_with_rs("S1", "GATTACAACGTACG", &["3M14B+T"]);
         let s2 = sample_with_rs("S2", "TTTTTTTGGGGGGG", &["3M7B7B+T"]);
-        let group = SampleGroup::from_samples(&[s1, s2]);
+        let group = SampleGroup::from_samples(&[s1, s2]).unwrap();
         assert!(group.has_per_sample_read_structures());
     }
 
@@ -790,18 +868,18 @@ mod tests {
     fn test_per_sample_read_structures_mixed_with_global_only_samples() {
         let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
         let s2 = Sample::new(0, "S2".to_owned(), "CCCCCCC".to_owned());
-        let group = SampleGroup::from_samples(&[s1, s2]);
+        let group = SampleGroup::from_samples(&[s1, s2]).unwrap();
         assert!(group.has_per_sample_read_structures());
         assert!(group.samples[0].read_structures.is_some());
         assert!(group.samples[1].read_structures.is_none());
     }
 
     #[test]
-    #[should_panic(expected = "barcode column has")]
     fn test_per_sample_read_structures_barcode_length_mismatch() {
         // S1 declares 7B + 7B = 14 bases of barcode but provides only 7 in the column.
         let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T", "3M7B1S+T"]);
-        let _ = SampleGroup::from_samples(&[s1]);
+        let err = SampleGroup::from_samples(&[s1]).unwrap_err();
+        assert!(err.to_string().contains("barcode column has"), "got: {err:#}");
     }
 
     #[test]
@@ -809,7 +887,7 @@ mod tests {
         // S1 prefix per input: 3+7+1 = 11; S2 prefix: 3+1+7+1 = 12
         let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
         let s2 = sample_with_rs("S2", "GGGGGGG", &["3M1S7B1S+T"]);
-        let group = SampleGroup::from_samples(&[s1, s2]);
+        let group = SampleGroup::from_samples(&[s1, s2]).unwrap();
         let defaults = vec![make_rs("3M9B+T")];
         let lens = group.matching_prefix_lens(&defaults).unwrap();
         assert_eq!(lens, vec![12]);
@@ -819,7 +897,7 @@ mod tests {
     fn test_build_matching_patterns_codec_two_samples() {
         let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
         let s2 = sample_with_rs("S2", "GGGGGGG", &["3M1S7B1S+T"]);
-        let group = SampleGroup::from_samples(&[s1, s2]);
+        let group = SampleGroup::from_samples(&[s1, s2]).unwrap();
         let defaults = vec![make_rs("3M9B+T")];
         let lens = group.matching_prefix_lens(&defaults).unwrap();
         let patterns = group.build_matching_patterns(&defaults, &lens).unwrap();
@@ -833,7 +911,7 @@ mod tests {
     #[test]
     fn test_build_matching_patterns_falls_back_to_defaults_when_no_per_sample() {
         let s1 = Sample::new(0, "S1".to_owned(), "GATTACA".to_owned());
-        let group = SampleGroup::from_samples(&[s1]);
+        let group = SampleGroup::from_samples(&[s1]).unwrap();
         let defaults = vec![make_rs("3M7B1S+T")];
         let lens = group.matching_prefix_lens(&defaults).unwrap();
         assert_eq!(lens, vec![11]);
@@ -847,7 +925,7 @@ mod tests {
         // two B-segments left-to-right across inputs.
         let s1 = sample_with_rs("S1", "GATTACAACGTACG", &["3M7B1S+T", "7B+T"]);
         let s2 = sample_with_rs("S2", "GGGGGGGTTTTTTT", &["3M1S7B1S+T", "1S7B+T"]);
-        let group = SampleGroup::from_samples(&[s1, s2]);
+        let group = SampleGroup::from_samples(&[s1, s2]).unwrap();
         let defaults = vec![make_rs("3M9B+T"), make_rs("9B+T")];
         let lens = group.matching_prefix_lens(&defaults).unwrap();
         // Input 1: max(11, 12) = 12; Input 2: max(7, 8) = 8.
@@ -867,7 +945,7 @@ mod tests {
     #[test]
     fn test_build_matching_patterns_b_segment_crossing_window_errors() {
         let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
-        let group = SampleGroup::from_samples(&[s1]);
+        let group = SampleGroup::from_samples(&[s1]).unwrap();
         let defaults = vec![make_rs("3M7B1S+T")];
         let lens = vec![5usize]; // forced narrow window for the test
         let err = group.build_matching_patterns(&defaults, &lens).unwrap_err();
@@ -877,7 +955,7 @@ mod tests {
 
     /// A `SampleGroup` constructed directly (bypassing `from_samples`' barcode-length
     /// validation) whose barcode is shorter than its read structure's sample-barcode
-    /// segments surfaces a clean error rather than panicking on an out-of-bounds slice.
+    /// segments surfaces a clean error naming the declared vs. provided barcode lengths.
     #[test]
     fn test_build_matching_patterns_barcode_shorter_than_b_segments_errors() {
         // `3M7B1S+T` requires 7 barcode bases, but the barcode column only has 3.
@@ -887,7 +965,52 @@ mod tests {
         let lens = vec![11usize];
         let err = group.build_matching_patterns(&defaults, &lens).unwrap_err();
         let msg = format!("{err:#}");
-        assert!(msg.contains("shorter than the total sample-barcode length"), "got: {msg}");
+        assert!(
+            msg.contains("declare 7 sample-barcode (B) base(s) but the barcode column has 3"),
+            "got: {msg}",
+        );
+    }
+
+    /// A sample-barcode (B) segment positioned after the template is rejected with a clear
+    /// message rather than the cryptic "only consumed N of M barcode bases".
+    #[test]
+    fn test_build_matching_patterns_barcode_after_template_errors() {
+        // 4B10T8B: barcode segments straddle the template; the trailing 8B can never match.
+        let s1 = sample_with_rs("S1", "ACGTACGTACGT", &["4B10T8B"]);
+        let group = SampleGroup::from_samples(&[s1]).unwrap();
+        let defaults = vec![make_rs("4B10T8B")];
+        let lens = group.matching_prefix_lens(&defaults).unwrap();
+        let err = group.build_matching_patterns(&defaults, &lens).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("must precede the template"), "got: {msg}");
+    }
+
+    /// A global-only sample (mixed mode) whose barcode length doesn't match the global
+    /// `--read-structures` B-length is rejected with a message pointing at the fallback.
+    #[test]
+    fn test_build_matching_patterns_global_only_barcode_mismatch_errors() {
+        // S1 (per-sample 6B) and S2 (global-only) both have 6-base barcodes, but the global
+        // structure declares 7 B bases, so S2's effective structure doesn't match its barcode.
+        let s1 = sample_with_rs("S1", "GATTAC", &["3M6B1S+T"]);
+        let s2 = Sample::new(0, "S2".to_owned(), "CCCCCC".to_owned());
+        let group = SampleGroup::from_samples(&[s1, s2]).unwrap();
+        let defaults = vec![make_rs("3M7B1S+T")];
+        let lens = group.matching_prefix_lens(&defaults).unwrap();
+        let err = group.build_matching_patterns(&defaults, &lens).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("--read-structures fallback") && msg.contains("S2"), "got: {msg}",);
+    }
+
+    /// In per-sample mode every input's pre-template segments must be fixed length; a variable
+    /// pre-template segment yields a message explaining the fixed-window requirement.
+    #[test]
+    fn test_matching_prefix_lens_variable_pre_template_errors() {
+        let s1 = sample_with_rs("S1", "ACGTACGT", &["8B+M"]);
+        let group = SampleGroup::from_samples(&[s1]).unwrap();
+        let defaults = vec![make_rs("8B+M")];
+        let err = group.matching_prefix_lens(&defaults).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("fixed-length matching window"), "got: {msg}");
     }
 
     // ############################################################################################
@@ -999,7 +1122,7 @@ mod tests {
     fn test_matching_prefix_lens_errors_on_rs_count_mismatch() {
         // Sample declares two read structures; defaults provide only one.
         let s1 = sample_with_rs("S1", "GATTACAGGGGGGG", &["3M7B1S+T", "7B+T"]);
-        let group = SampleGroup::from_samples(&[s1]);
+        let group = SampleGroup::from_samples(&[s1]).unwrap();
         let defaults = vec![make_rs("3M7B+T")];
         let err = group.matching_prefix_lens(&defaults).unwrap_err();
         let msg = format!("{err:#}");

--- a/src/lib/samples.rs
+++ b/src/lib/samples.rs
@@ -1,34 +1,38 @@
 use crate::is_valid_iupac;
 
-use anyhow::Result;
-use fgoxide::io::DelimFile;
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use fgoxide::io::Io;
 use itertools::Itertools;
-use serde::Deserialize;
-use serde_aux::prelude::*;
-use std::collections::HashSet;
-use std::collections::hash_map::RandomState;
+use read_structure::{ReadStructure, SegmentType};
 use std::fmt::{self, Display};
 use std::path::Path;
+use std::str::FromStr;
 
 const DEFAULT_FILE_DELIMETER: u8 = b'\t';
+const SAMPLE_ID_HEADER: &str = "sample_id";
+const BARCODE_HEADER: &str = "barcode";
+const READ_STRUCTURE_PREFIX: &str = "read_structure_";
 
 /// Struct for describing a single sample and metadata associated with that sample.
-#[derive(Clone, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Sample {
     /// ID of the sample or library
     pub sample_id: String,
     /// DNA barcode associated with the sample
     pub barcode: String,
-    /// index of the sample in the [`SampleGroup`] object, used for syncing indices across
-    /// different structs
-    #[serde(skip_deserializing)]
+    /// Optional per-sample read structures (one per input FASTQ).  When present, these
+    /// override the global `--read-structures` for this sample, both for matching pattern
+    /// construction and for output extraction.
+    pub read_structures: Option<Vec<ReadStructure>>,
+    /// Index of the sample in the [`SampleGroup`] object, used for syncing indices across
+    /// different structs.
     pub(crate) ordinal: usize,
 }
 
 impl Display for Sample {
     /// Implements a nice format display for the [`Sample`] struct.
     /// E.g. A sample with ordinal 2, name test-sample, and barcode GATTACA would look like:
-    /// Sample(0002) - { name: test-sample    barcode: GATTACA}
+    /// Sample(0002) - { name: test-sample    barcode: GATTACA }
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -44,35 +48,41 @@ impl Sample {
     /// # Panics
     ///   - Panics if sample name is empty string.
     ///   - Panics if barcode is empty string.
-    ///   - Panics if barcode has bases other than A, C, G, T, or N/n/.
+    ///   - Panics if barcode has bases other than A, C, G, T, U, R, Y, S, W, K, M, D, V, H, B, or
+    ///     N/n/.
     #[must_use]
     pub fn new(ordinal: usize, name: String, barcode: String) -> Self {
+        Self::with_read_structures(ordinal, name, barcode, None)
+    }
+
+    /// Like [`Sample::new`] but allows attaching per-sample read structures.
+    #[must_use]
+    pub fn with_read_structures(
+        ordinal: usize,
+        name: String,
+        barcode: String,
+        read_structures: Option<Vec<ReadStructure>>,
+    ) -> Self {
         assert!(!name.is_empty(), "Sample name cannot be empty");
         assert!(!barcode.is_empty(), "Sample barcode cannot be empty");
         assert!(
             barcode.as_bytes().iter().all(|&b| is_valid_iupac(b)),
             "All sample barcode bases must be one of A, C, G, T, U, R, Y, S, W, K, M, D, V, H, B, N"
         );
-        Self { sample_id: name, barcode, ordinal }
+        Self { sample_id: name, barcode, read_structures, ordinal }
     }
 
-    /// Returns the header line expected by serde when deserializing
+    /// Returns the header line expected by the metadata file deserializer.  Only the two required
+    /// columns are reported; per-sample `read_structure_<n>` columns are optional.
     #[must_use]
     pub fn deserialize_header_line() -> String {
-        let field_names = serde_introspect::<Self>();
-        let skip_deserialize_fields: HashSet<&str, RandomState> = HashSet::from_iter(["ordinal"]);
-        let final_field_names: Vec<String> = field_names
-            .iter()
-            .filter(|&&f| !skip_deserialize_fields.contains(f))
-            .map(|&f| f.to_owned())
-            .collect();
-        final_field_names.join("\t")
+        format!("{SAMPLE_ID_HEADER}\t{BARCODE_HEADER}")
     }
 }
 
 /// Struct for storing information about multiple samples and for defining functions associated
 /// with groups of [`Sample`]s, rather than individual structs.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SampleGroup {
     /// A group of samples
     pub samples: Vec<Sample>,
@@ -89,70 +99,411 @@ impl Display for SampleGroup {
 }
 
 impl SampleGroup {
-    /// Validates a group of [`Sample`]s and instantiates a [`Self`] struct if they are
-    /// valid. Will clone the [`Sample`] structs and change the number on the `ordinal` field on
-    /// those cloned to match the order in which they are stored in this [`Self`]
+    /// Validates a group of [`Sample`]s and instantiates a [`Self`] struct if they are valid. Will
+    /// clone the [`Sample`] structs and change the number on the `ordinal` field on those cloned
+    /// to match the order in which they are stored in this [`Self`].
+    ///
+    /// Per-sample read structures may differ in their per-input `(T, B, M, C)` segment counts
+    /// across samples (which lets each sample produce a different set of output files), but
+    /// the total length of all sample-barcode (`B`) segments per sample must equal the
+    /// `barcode` column for that sample (and barcodes are required to be the same length).
+    ///
     /// # Panics
-    ///   - Will panic if sample metadata sheet is improperly formatted
-    ///   - Will panic if there are duplicate sample names provided
-    ///   - Will panic if there are duplicate barcodes provided
-    ///   - Will panic if barcodes don't all have the same length
+    ///   - Will panic if sample metadata sheet is improperly formatted.
+    ///   - Will panic if there are duplicate sample names provided.
+    ///   - Will panic if there are duplicate barcodes provided.
+    ///   - Will panic if barcodes don't all have the same length.
+    ///   - Will panic if any sample's per-sample sample-barcode (`B`) segment lengths don't
+    ///     sum to that sample's `barcode` column length.
     #[must_use]
     pub fn from_samples(samples: &[Sample]) -> Self {
-        // Validate that we have at least one name
         assert!(!samples.is_empty(), "Must provide one or more sample");
 
-        // Validate that all the sample names are unique
         assert!(
             samples.iter().map(|s| &s.sample_id).all_unique(),
             "Each sample name must be unique, duplicate identified"
         );
 
-        // Validate that the barcodes are all unique
         assert!(
             samples.iter().map(|s| &s.barcode).all_unique(),
             "Each sample barcode must be unique, duplicate identified",
         );
 
-        // Validate that the barcodes are all of the same length
         let first_barcode_length = samples[0].barcode.len();
         assert!(
             samples.iter().map(|s| &s.barcode).all(|b| b.len() == first_barcode_length),
             "All barcodes must have the same length",
         );
 
+        // Per-sample read structures (when present) must have B-segments whose lengths sum to
+        // the sample's `barcode` column length.  Sample-barcode segments must be fixed-length.
+        for sample in samples {
+            let Some(rs) = sample.read_structures.as_ref() else { continue };
+            let b_len: usize = rs
+                .iter()
+                .flat_map(|r| r.segments_by_type(SegmentType::SampleBarcode))
+                .map(|seg| {
+                    seg.length.expect(
+                        "sample barcode segments in per-sample read structures must be fixed \
+                         length",
+                    )
+                })
+                .sum();
+            assert!(
+                b_len == sample.barcode.len(),
+                "Sample {}: total sample-barcode (B) length across per-sample read structures \
+                 is {} but barcode column has {} bases",
+                sample.sample_id,
+                b_len,
+                sample.barcode.len(),
+            );
+        }
+
         Self {
             samples: samples
                 .iter()
                 .enumerate()
                 .map(|(ordinal, sample)| {
-                    Sample::new(ordinal, sample.sample_id.clone(), sample.barcode.clone())
+                    Sample::with_read_structures(
+                        ordinal,
+                        sample.sample_id.clone(),
+                        sample.barcode.clone(),
+                        sample.read_structures.clone(),
+                    )
                 })
                 .collect(),
         }
     }
 
-    /// Attempts to load a [`Self`] object from a file. File should be delimeted with
-    /// `delimiter`, should have a header with `name` and `barcode` fields present.
+    /// Attempts to load a [`Self`] object from a tab-delimited file.  The file must have a header
+    /// row containing at least the columns `sample_id` and `barcode`.  Optional additional columns
+    /// `read_structure_1`, `read_structure_2`, ..., `read_structure_<N>` attach per-sample read
+    /// structures to each sample (one per input FASTQ in the order given to `--inputs`).  When
+    /// these columns are present:
+    ///
+    /// - `globals` (the `--read-structures` argument) must have exactly `N` entries, one per
+    ///   input FASTQ.
+    /// - A blank cell in `read_structure_<i>` falls back to `globals[i-1]` for that sample.
+    /// - A row whose `read_structure_<n>` cells are all blank uses `globals` entirely (i.e. is
+    ///   equivalent to omitting the per-sample columns for that sample only).
+    ///
+    /// When no `read_structure_<n>` columns are present, `globals` is unused and every sample
+    /// uses the global structures.
+    ///
     /// # Errors
-    ///   - Will error if file cannot be read, either due to not the file not existing or due to
-    ///     the format being different from the format expected.
+    ///   - Will error if the file cannot be read.
+    ///   - Will error if the header row is missing required columns.
+    ///   - Will error if `read_structure_<n>` columns are non-contiguous or don't match
+    ///     `globals.len()` (when present).
+    ///   - Will error if any `read_structure_<n>` cell has a value that fails to parse.
     /// # Panics
-    ///   - Will panic if sample metadata sheet is improperly formatted
-    ///   - Will panic if a different number of names and barcodes are provided
-    ///   - Will panic if each
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<SampleGroup, fgoxide::FgError> {
-        let reader = DelimFile::default();
-        Ok(Self::from_samples(&reader.read(path, DEFAULT_FILE_DELIMETER, false)?))
+    ///   - Will panic if [`SampleGroup::from_samples`] panics on the parsed records.
+    pub fn from_file<P: AsRef<Path>>(path: P, globals: &[ReadStructure]) -> Result<SampleGroup> {
+        let path = path.as_ref();
+        let io = Io::default();
+        let lines = io
+            .read_lines(path)
+            .with_context(|| format!("failed to read sample metadata file {path:?}"))?;
+        let mut iter = lines.into_iter().filter(|l| !l.trim().is_empty());
+
+        let header = iter.next().ok_or_else(|| {
+            anyhow!(
+                "sample metadata file {path:?} is empty (expected header line {})",
+                Sample::deserialize_header_line(),
+            )
+        })?;
+        // Strip a UTF-8 BOM and any trailing CR so files saved on Windows or with a BOM
+        // (e.g. by Excel/Notepad) parse correctly.
+        let header = strip_bom_and_cr(&header);
+        let header_fields: Vec<&str> = header.split(DEFAULT_FILE_DELIMETER as char).collect();
+
+        let sample_id_idx =
+            header_fields.iter().position(|c| *c == SAMPLE_ID_HEADER).ok_or_else(|| {
+                anyhow!("sample metadata header is missing column `{SAMPLE_ID_HEADER}`")
+            })?;
+        let barcode_idx =
+            header_fields.iter().position(|c| *c == BARCODE_HEADER).ok_or_else(|| {
+                anyhow!("sample metadata header is missing column `{BARCODE_HEADER}`")
+            })?;
+
+        // Discover read_structure_<n> columns in header order; require contiguous indexing
+        // starting at 1 and a total count matching `globals.len()` (when present).
+        let mut rs_columns: Vec<(usize, usize)> = Vec::new(); // (n, header_idx)
+        for (idx, name) in header_fields.iter().enumerate() {
+            if let Some(suffix) = name.strip_prefix(READ_STRUCTURE_PREFIX) {
+                let n: usize = suffix
+                    .parse()
+                    .with_context(|| format!("metadata column `{name}` has non-integer suffix"))?;
+                ensure!(n >= 1, "metadata column `{name}` must use 1-based indexing");
+                rs_columns.push((n, idx));
+            }
+        }
+        rs_columns.sort_by_key(|(n, _)| *n);
+        for (i, (n, _)) in rs_columns.iter().enumerate() {
+            ensure!(
+                *n == i + 1,
+                "per-sample read structure columns must be contiguous starting at \
+                 `{READ_STRUCTURE_PREFIX}1` (found `{READ_STRUCTURE_PREFIX}{n}` at position {})",
+                i + 1,
+            );
+        }
+        if !rs_columns.is_empty() {
+            ensure!(
+                rs_columns.len() == globals.len(),
+                "metadata file has {} `{READ_STRUCTURE_PREFIX}<n>` column(s) but \
+                 `--read-structures` has {} entry/entries",
+                rs_columns.len(),
+                globals.len(),
+            );
+        }
+
+        let mut samples: Vec<Sample> = Vec::new();
+        for (line_no, line) in iter.enumerate() {
+            let row_no = line_no + 2; // header is line 1
+            let line = line.trim_end_matches('\r');
+            let cols: Vec<&str> = line.split(DEFAULT_FILE_DELIMETER as char).collect();
+            ensure!(
+                cols.len() == header_fields.len(),
+                "sample metadata row {row_no} has {} columns but header has {}",
+                cols.len(),
+                header_fields.len(),
+            );
+            let sample_id = cols[sample_id_idx].to_owned();
+            let barcode = cols[barcode_idx].to_owned();
+            let read_structures =
+                parse_per_sample_read_structures(row_no, &cols, &rs_columns, globals)?;
+            samples.push(Sample::with_read_structures(
+                samples.len(),
+                sample_id,
+                barcode,
+                read_structures,
+            ));
+        }
+
+        if samples.is_empty() {
+            bail!("sample metadata file {path:?} contained no sample rows");
+        }
+        Ok(Self::from_samples(&samples))
     }
+
+    /// Returns true if this group has per-sample read structures (i.e. at least one sample
+    /// carries custom read structures that override `--read-structures`).
+    #[must_use]
+    pub fn has_per_sample_read_structures(&self) -> bool {
+        self.samples.iter().any(|s| s.read_structures.is_some())
+    }
+
+    /// Returns the per-input matching prefix lengths needed to demultiplex this sample group.
+    /// For each input FASTQ index, this is the maximum across samples of the number of bases
+    /// before the first Template segment in that sample's read structure.  Falls back to the
+    /// corresponding entry in `default_structures` for samples without per-sample read
+    /// structures.
+    ///
+    /// # Errors
+    ///   - Returns an error if any non-Template segment in the matching window has a
+    ///     non-fixed length.
+    ///   - Returns an error if a sample's per-sample read-structure count differs from
+    ///     `default_structures.len()`.
+    pub fn matching_prefix_lens(&self, default_structures: &[ReadStructure]) -> Result<Vec<usize>> {
+        let n = default_structures.len();
+        let mut maxes = vec![0usize; n];
+        for sample in &self.samples {
+            let rs_for_sample = sample.read_structures.as_deref().unwrap_or(default_structures);
+            ensure!(
+                rs_for_sample.len() == n,
+                "sample {}: number of read structures ({}) does not match number of inputs ({})",
+                sample.sample_id,
+                rs_for_sample.len(),
+                n,
+            );
+            for (i, rs) in rs_for_sample.iter().enumerate() {
+                let plen = pre_template_fixed_len(rs)
+                    .with_context(|| format!("sample {} input {}", sample.sample_id, i + 1))?;
+                if plen > maxes[i] {
+                    maxes[i] = plen;
+                }
+            }
+        }
+        Ok(maxes)
+    }
+
+    /// Builds the matching pattern bytes for each sample.  The pattern is a fixed-length
+    /// byte sequence (concatenated across all input FASTQs) of total length
+    /// `prefix_lens.iter().sum()`.  For each input, the sample's read structure is walked
+    /// position-by-position; B (sample-barcode) segment positions are filled from
+    /// `sample.barcode` (taken in order across inputs), and M/S/C/T segment positions and any
+    /// trailing positions up to the prefix length are filled with `N` (treated as a wildcard
+    /// by the matcher).
+    ///
+    /// # Errors
+    ///   - Returns an error if any sample's read structure has a non-fixed-length non-template
+    ///     segment in the matching window.
+    ///   - Returns an error if a sample-barcode (`B`) segment crosses the matching window
+    ///     boundary, since silently truncating a barcode would corrupt matching.
+    pub fn build_matching_patterns(
+        &self,
+        default_structures: &[ReadStructure],
+        prefix_lens: &[usize],
+    ) -> Result<Vec<Vec<u8>>> {
+        ensure!(
+            default_structures.len() == prefix_lens.len(),
+            "expected one prefix length per input FASTQ"
+        );
+        let total_len: usize = prefix_lens.iter().sum();
+        let mut patterns = Vec::with_capacity(self.samples.len());
+        for sample in &self.samples {
+            let rs_for_sample = sample.read_structures.as_deref().unwrap_or(default_structures);
+            ensure!(
+                rs_for_sample.len() == prefix_lens.len(),
+                "sample {}: number of read structures ({}) does not match number of inputs ({})",
+                sample.sample_id,
+                rs_for_sample.len(),
+                prefix_lens.len(),
+            );
+            let mut pattern = Vec::with_capacity(total_len);
+            let mut barcode_cursor = 0usize;
+            let barcode_bytes = sample.barcode.as_bytes();
+            for (rs, &prefix_len) in rs_for_sample.iter().zip(prefix_lens) {
+                let mut filled = 0usize;
+                for seg in rs.iter() {
+                    if seg.kind == SegmentType::Template {
+                        break;
+                    }
+                    let len = seg.length.ok_or_else(|| {
+                        anyhow!(
+                            "sample {}: non-template segment {seg} in read structure must have a \
+                             fixed length",
+                            sample.sample_id,
+                        )
+                    })?;
+                    let remaining = prefix_len - filled;
+                    let take = len.min(remaining);
+                    if seg.kind == SegmentType::SampleBarcode {
+                        ensure!(
+                            take == len,
+                            "sample {}: sample-barcode segment {seg} crosses the matching \
+                             window boundary (segment length {}, but only {} bases remain in \
+                             the {}-base window)",
+                            sample.sample_id,
+                            len,
+                            remaining,
+                            prefix_len,
+                        );
+                        ensure!(
+                            barcode_cursor + len <= barcode_bytes.len(),
+                            "sample {}: barcode ({} bases) is shorter than the total \
+                             sample-barcode length required by its read structure",
+                            sample.sample_id,
+                            barcode_bytes.len(),
+                        );
+                        pattern.extend_from_slice(
+                            &barcode_bytes[barcode_cursor..barcode_cursor + len],
+                        );
+                        barcode_cursor += len;
+                    } else {
+                        pattern.extend(std::iter::repeat_n(b'N', take));
+                    }
+                    filled += take;
+                    if take < len {
+                        break;
+                    }
+                }
+                if filled < prefix_len {
+                    pattern.extend(std::iter::repeat_n(b'N', prefix_len - filled));
+                }
+            }
+            ensure!(
+                barcode_cursor == sample.barcode.len(),
+                "sample {}: only consumed {} of {} barcode bases when building matching pattern",
+                sample.sample_id,
+                barcode_cursor,
+                sample.barcode.len(),
+            );
+            patterns.push(pattern);
+        }
+        Ok(patterns)
+    }
+}
+
+/// Resolves the per-sample read structure cells for one row of the metadata file.  Returns
+/// `None` if `rs_columns` is empty or every cell is blank (sample uses globals entirely);
+/// otherwise returns `Some(vec)` with each blank cell replaced by `globals[i]`.
+///
+/// Sample-barcode (`B`) segments in any parsed cell must be fixed length: a variable-length
+/// `+B` is rejected here so the error surfaces as a normal `Result` rather than panicking
+/// later during `from_samples` validation.
+fn parse_per_sample_read_structures(
+    row_no: usize,
+    cols: &[&str],
+    rs_columns: &[(usize, usize)],
+    globals: &[ReadStructure],
+) -> Result<Option<Vec<ReadStructure>>> {
+    if rs_columns.is_empty() {
+        return Ok(None);
+    }
+    let mut entries: Vec<Option<ReadStructure>> = Vec::with_capacity(rs_columns.len());
+    for (n, idx) in rs_columns {
+        let raw = cols[*idx].trim();
+        if raw.is_empty() {
+            entries.push(None);
+        } else {
+            let rs = ReadStructure::from_str(raw).with_context(|| {
+                format!(
+                    "sample metadata row {row_no} column `{READ_STRUCTURE_PREFIX}{n}` has \
+                     invalid read structure `{raw}`",
+                )
+            })?;
+            for seg in rs.segments_by_type(SegmentType::SampleBarcode) {
+                ensure!(
+                    seg.length.is_some(),
+                    "sample metadata row {row_no} column `{READ_STRUCTURE_PREFIX}{n}`: \
+                     sample-barcode segment {seg} must be fixed length (variable-length `+B` \
+                     is not supported in per-sample read structures)",
+                );
+            }
+            entries.push(Some(rs));
+        }
+    }
+    if entries.iter().all(Option::is_none) {
+        return Ok(None);
+    }
+    let resolved: Vec<ReadStructure> = entries
+        .into_iter()
+        .enumerate()
+        .map(|(i, e)| e.unwrap_or_else(|| globals[i].clone()))
+        .collect();
+    Ok(Some(resolved))
+}
+
+/// Strips a leading UTF-8 byte-order mark and any trailing carriage return from a line so that
+/// files saved with a BOM or CRLF line endings parse correctly.
+fn strip_bom_and_cr(s: &str) -> &str {
+    s.strip_prefix('\u{FEFF}').unwrap_or(s).trim_end_matches('\r')
+}
+
+/// Returns the offset of the first Template segment in a read structure.  If the read structure
+/// has no Template segments, returns the sum of all (fixed-length) segment lengths.
+///
+/// # Errors
+///   - Returns an error if a non-Template segment lacks a fixed length.
+fn pre_template_fixed_len(rs: &ReadStructure) -> Result<usize> {
+    let mut len = 0;
+    for seg in rs.iter() {
+        if seg.kind == SegmentType::Template {
+            return Ok(len);
+        }
+        len += seg.length.ok_or_else(|| {
+            anyhow!("non-template segment {seg} in read structure {rs} must have a fixed length")
+        })?;
+    }
+    Ok(len)
 }
 
 #[cfg(test)]
 mod tests {
-    use core::panic;
-
     use super::*;
-    use fgoxide::{self, io::Io};
+    use fgoxide::io::Io;
+    use std::str::FromStr;
     use tempfile::TempDir;
 
     // ############################################################################################
@@ -170,12 +521,13 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        let samples_metadata = SampleGroup::from_file(&f1).unwrap();
+        let samples_metadata = SampleGroup::from_file(&f1, &[]).unwrap();
 
         assert!(samples_metadata.samples[0].sample_id == "sample1");
         assert!(samples_metadata.samples[1].sample_id == "sample2");
         assert!(samples_metadata.samples[0].barcode == "GATTACA");
         assert!(samples_metadata.samples[1].barcode == "CATGCTA");
+        assert!(!samples_metadata.has_per_sample_read_structures());
     }
 
     #[test]
@@ -192,7 +544,7 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        let samples_metadata = SampleGroup::from_file(&f1).unwrap();
+        let samples_metadata = SampleGroup::from_file(&f1, &[]).unwrap();
 
         assert!(samples_metadata.samples[0].sample_id == "sample1");
         assert!(samples_metadata.samples[1].sample_id == "sample2");
@@ -219,18 +571,13 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        let err = SampleGroup::from_file(&f1).unwrap_err();
-
-        if let fgoxide::FgError::DelimFileHeaderError { expected, found } = err {
-            assert_eq!(expected, Sample::deserialize_header_line());
-            assert_eq!(found, "sample_id,barcode");
-        } else {
-            panic!()
-        }
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("missing column `sample_id`"), "got: {msg}");
     }
 
     // ############################################################################################
-    // Test [`SampleGroup::from_file`] - Expected to panic
+    // Test [`SampleGroup::from_file`] - Expected to error or panic
     // ############################################################################################
     #[test]
     fn test_reading_from_file_with_no_header() {
@@ -240,18 +587,12 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        if let fgoxide::FgError::DelimFileHeaderError { expected, found } =
-            SampleGroup::from_file(&f1).unwrap_err()
-        {
-            assert_eq!(expected, Sample::deserialize_header_line());
-            assert_eq!(found, "sample1\tGATTACA");
-        } else {
-            panic!("Different error type than expected reading from headerless file.")
-        }
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("missing column `sample_id`"), "got: {msg}");
     }
 
     #[test]
-    #[should_panic(expected = "Must provide one or more sample")]
     fn test_reading_header_only_file() {
         let lines = vec![Sample::deserialize_header_line()];
         let tempdir = TempDir::new().unwrap();
@@ -259,11 +600,12 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        let _sm = SampleGroup::from_file(&f1).unwrap();
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("contained no sample rows"), "got: {msg}");
     }
 
     #[test]
-    #[should_panic(expected = "Must provide one or more sample")]
     fn test_reading_empty_file() {
         let lines = vec![""];
         let tempdir = TempDir::new().unwrap();
@@ -271,18 +613,18 @@ mod tests {
 
         let io = Io::default();
         io.write_lines(&f1, &lines).unwrap();
-        let _sm = SampleGroup::from_file(&f1).unwrap();
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("is empty") || msg.contains("missing column"), "got: {msg}");
     }
 
     #[test]
     fn test_reading_non_existent_file() {
         let tempdir = TempDir::new().unwrap();
         let f1 = tempdir.path().join("sample_metadata.tsv");
-        if let fgoxide::FgError::IoError(e) = SampleGroup::from_file(&f1).unwrap_err() {
-            assert_eq!(e.to_string(), "No such file or directory (os error 2)");
-        } else {
-            panic!("Different error than expected reading non-existent file")
-        }
+        let err = SampleGroup::from_file(&f1, &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("failed to read sample metadata file"), "got: {msg}");
     }
 
     // ############################################################################################
@@ -295,7 +637,7 @@ mod tests {
         let ordinal = 0;
         let sample = Sample::new(ordinal, name.clone(), barcode.clone());
         assert_eq!(
-            Sample { sample_id: name, barcode, ordinal },
+            Sample { sample_id: name, barcode, read_structures: None, ordinal },
             sample,
             "Sample differed from expectation"
         );
@@ -304,7 +646,6 @@ mod tests {
     // ############################################################################################
     // Test [`Sample::new`] - Expected to panic
     // ############################################################################################
-
     #[test]
     #[should_panic(expected = "Sample name cannot be empty")]
     fn test_new_sample_fail1_empty_sample_name() {
@@ -394,5 +735,322 @@ mod tests {
             Sample::new(0, "sample_2".to_owned(), "CATGGA".to_owned()),
         ];
         let _sample_group = SampleGroup::from_samples(&samples);
+    }
+
+    // ############################################################################################
+    // Tests for per-sample read structures.
+    // ############################################################################################
+    fn make_rs(s: &str) -> ReadStructure {
+        ReadStructure::from_str(s).unwrap()
+    }
+
+    fn sample_with_rs(name: &str, barcode: &str, structures: &[&str]) -> Sample {
+        let rs = structures.iter().map(|s| make_rs(s)).collect();
+        Sample::with_read_structures(0, name.to_owned(), barcode.to_owned(), Some(rs))
+    }
+
+    fn write_metadata(tempdir: &TempDir, lines: &[String]) -> std::path::PathBuf {
+        let f1 = tempdir.path().join("metadata.tsv");
+        Io::default().write_lines(&f1, lines).unwrap();
+        f1
+    }
+
+    #[test]
+    fn test_per_sample_read_structures_round_trip_via_metadata() {
+        // Two-input case: each input contributes 7B, so the barcode column carries 14 bases.
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_1\tread_structure_2".to_owned(),
+            "S1\tGATTACAACGTACG\t3M7B1S+T\t3M7B1S+T".to_owned(),
+            "S2\tGGGGGGGTTTTTTT\t3M1S7B1S+T\t3M1S7B1S+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M9B+T"), make_rs("9B+T")];
+        let group = SampleGroup::from_file(&f1, &globals).unwrap();
+        assert!(group.has_per_sample_read_structures());
+        let s1_rs = group.samples[0].read_structures.as_ref().unwrap();
+        assert_eq!(s1_rs.len(), 2);
+        let s2_rs = group.samples[1].read_structures.as_ref().unwrap();
+        assert_eq!(s2_rs.len(), 2);
+    }
+
+    /// Per-sample read structures may have differing per-input `(T, B, M, C)` segment counts
+    /// across samples, as long as each sample's B-segment lengths sum to its `barcode` column.
+    #[test]
+    fn test_per_sample_read_structures_signatures_may_differ_across_samples() {
+        // S1 has one B-segment of length 14; S2 has two B-segments (7+7) of total length 14.
+        let s1 = sample_with_rs("S1", "GATTACAACGTACG", &["3M14B+T"]);
+        let s2 = sample_with_rs("S2", "TTTTTTTGGGGGGG", &["3M7B7B+T"]);
+        let group = SampleGroup::from_samples(&[s1, s2]);
+        assert!(group.has_per_sample_read_structures());
+    }
+
+    /// Mixed mode: some samples have per-sample read structures, others fall back to globals.
+    #[test]
+    fn test_per_sample_read_structures_mixed_with_global_only_samples() {
+        let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
+        let s2 = Sample::new(0, "S2".to_owned(), "CCCCCCC".to_owned());
+        let group = SampleGroup::from_samples(&[s1, s2]);
+        assert!(group.has_per_sample_read_structures());
+        assert!(group.samples[0].read_structures.is_some());
+        assert!(group.samples[1].read_structures.is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "barcode column has")]
+    fn test_per_sample_read_structures_barcode_length_mismatch() {
+        // S1 declares 7B + 7B = 14 bases of barcode but provides only 7 in the column.
+        let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T", "3M7B1S+T"]);
+        let _ = SampleGroup::from_samples(&[s1]);
+    }
+
+    #[test]
+    fn test_matching_prefix_lens_uses_max_across_samples() {
+        // S1 prefix per input: 3+7+1 = 11; S2 prefix: 3+1+7+1 = 12
+        let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
+        let s2 = sample_with_rs("S2", "GGGGGGG", &["3M1S7B1S+T"]);
+        let group = SampleGroup::from_samples(&[s1, s2]);
+        let defaults = vec![make_rs("3M9B+T")];
+        let lens = group.matching_prefix_lens(&defaults).unwrap();
+        assert_eq!(lens, vec![12]);
+    }
+
+    #[test]
+    fn test_build_matching_patterns_codec_two_samples() {
+        let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
+        let s2 = sample_with_rs("S2", "GGGGGGG", &["3M1S7B1S+T"]);
+        let group = SampleGroup::from_samples(&[s1, s2]);
+        let defaults = vec![make_rs("3M9B+T")];
+        let lens = group.matching_prefix_lens(&defaults).unwrap();
+        let patterns = group.build_matching_patterns(&defaults, &lens).unwrap();
+        // Total length is 12 for each pattern.
+        // S1: NNN + GATTACA + N (S=skip wildcarded) + N (padding to 12)
+        assert_eq!(patterns[0], b"NNNGATTACANN");
+        // S2: NNN + N (S=stagger wildcarded) + GGGGGGG + N (S=trailing wildcarded)
+        assert_eq!(patterns[1], b"NNNNGGGGGGGN");
+    }
+
+    #[test]
+    fn test_build_matching_patterns_falls_back_to_defaults_when_no_per_sample() {
+        let s1 = Sample::new(0, "S1".to_owned(), "GATTACA".to_owned());
+        let group = SampleGroup::from_samples(&[s1]);
+        let defaults = vec![make_rs("3M7B1S+T")];
+        let lens = group.matching_prefix_lens(&defaults).unwrap();
+        assert_eq!(lens, vec![11]);
+        let patterns = group.build_matching_patterns(&defaults, &lens).unwrap();
+        assert_eq!(patterns[0], b"NNNGATTACAN");
+    }
+
+    #[test]
+    fn test_build_matching_patterns_dual_input_concatenated() {
+        // Two inputs, each with its own staggered structure; barcode column concatenates the
+        // two B-segments left-to-right across inputs.
+        let s1 = sample_with_rs("S1", "GATTACAACGTACG", &["3M7B1S+T", "7B+T"]);
+        let s2 = sample_with_rs("S2", "GGGGGGGTTTTTTT", &["3M1S7B1S+T", "1S7B+T"]);
+        let group = SampleGroup::from_samples(&[s1, s2]);
+        let defaults = vec![make_rs("3M9B+T"), make_rs("9B+T")];
+        let lens = group.matching_prefix_lens(&defaults).unwrap();
+        // Input 1: max(11, 12) = 12; Input 2: max(7, 8) = 8.
+        assert_eq!(lens, vec![12, 8]);
+        let patterns = group.build_matching_patterns(&defaults, &lens).unwrap();
+        // Total pattern length: 12 + 8 = 20.
+        let mut expected_s1 = b"NNNGATTACANN".to_vec();
+        expected_s1.extend_from_slice(b"ACGTACGN");
+        assert_eq!(patterns[0], expected_s1);
+        let mut expected_s2 = b"NNNNGGGGGGGN".to_vec();
+        expected_s2.extend_from_slice(b"NTTTTTTT");
+        assert_eq!(patterns[1], expected_s2);
+    }
+
+    /// A sample-barcode segment crossing the matching window is rejected with a clear error
+    /// rather than silently truncated.
+    #[test]
+    fn test_build_matching_patterns_b_segment_crossing_window_errors() {
+        let s1 = sample_with_rs("S1", "GATTACA", &["3M7B1S+T"]);
+        let group = SampleGroup::from_samples(&[s1]);
+        let defaults = vec![make_rs("3M7B1S+T")];
+        let lens = vec![5usize]; // forced narrow window for the test
+        let err = group.build_matching_patterns(&defaults, &lens).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("crosses the matching window boundary"), "got: {msg}");
+    }
+
+    /// A `SampleGroup` constructed directly (bypassing `from_samples`' barcode-length
+    /// validation) whose barcode is shorter than its read structure's sample-barcode
+    /// segments surfaces a clean error rather than panicking on an out-of-bounds slice.
+    #[test]
+    fn test_build_matching_patterns_barcode_shorter_than_b_segments_errors() {
+        // `3M7B1S+T` requires 7 barcode bases, but the barcode column only has 3.
+        let s1 = sample_with_rs("S1", "GAT", &["3M7B1S+T"]);
+        let group = SampleGroup { samples: vec![s1] };
+        let defaults = vec![make_rs("3M7B1S+T")];
+        let lens = vec![11usize];
+        let err = group.build_matching_patterns(&defaults, &lens).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("shorter than the total sample-barcode length"), "got: {msg}");
+    }
+
+    // ############################################################################################
+    // Per-cell fallback tests for `from_file`.
+    // ############################################################################################
+    /// A blank `read_structure_<n>` cell falls back to `globals[n-1]` for that sample.
+    #[test]
+    fn test_per_cell_fallback_uses_globals_for_blank_cells() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_1\tread_structure_2".to_owned(),
+            // S1 overrides only input 1; input 2 is blank → uses globals[1].
+            "S1\tGATTACAGGGGGGG\t3M7B1S+T\t".to_owned(),
+            // S2 overrides only input 2; input 1 is blank → uses globals[0].
+            "S2\tCCCCCCCAAAAAAA\t\t1S7B+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T"), make_rs("7B+T")];
+        let group = SampleGroup::from_file(&f1, &globals).unwrap();
+        let s1_rs = group.samples[0].read_structures.as_ref().unwrap();
+        assert_eq!(s1_rs.len(), 2);
+        assert_eq!(s1_rs[0].to_string(), "3M7B1S+T");
+        assert_eq!(s1_rs[1].to_string(), "7B+T");
+        let s2_rs = group.samples[1].read_structures.as_ref().unwrap();
+        assert_eq!(s2_rs[0].to_string(), "3M7B+T");
+        assert_eq!(s2_rs[1].to_string(), "1S7B+T");
+    }
+
+    /// A row whose `read_structure_<n>` cells are all blank uses globals entirely (the
+    /// sample's stored `read_structures` is `None`).
+    #[test]
+    fn test_per_cell_all_blank_row_falls_back_to_globals_entirely() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_1\tread_structure_2".to_owned(),
+            "S1\tGATTACAGGGGGGG\t3M7B1S+T\t3M7B1S+T".to_owned(),
+            "S2\tCCCCCCCAAAAAAA\t\t".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T"), make_rs("3M7B+T")];
+        let group = SampleGroup::from_file(&f1, &globals).unwrap();
+        assert!(group.samples[0].read_structures.is_some());
+        assert!(group.samples[1].read_structures.is_none());
+    }
+
+    /// `read_structure_<n>` column count must match `globals.len()` when columns are present.
+    #[test]
+    fn test_per_sample_column_count_must_match_globals() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_1".to_owned(),
+            "S1\tGATTACA\t3M7B1S+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T"), make_rs("100T")];
+        let err = SampleGroup::from_file(&f1, &globals).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("`read_structure_<n>` column(s)") && msg.contains("--read-structures"),
+            "got: {msg}",
+        );
+    }
+
+    /// A variable-length sample-barcode (`+B`) in a per-sample column must surface as a
+    /// normal `Result` error rather than panic during downstream validation.
+    #[test]
+    fn test_per_sample_variable_length_b_segment_errors() {
+        let lines =
+            vec!["sample_id\tbarcode\tread_structure_1".to_owned(), "S1\tGATTACA\t3M+B".to_owned()];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T")];
+        let err = SampleGroup::from_file(&f1, &globals).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("must be fixed length"), "got: {msg}");
+    }
+
+    /// A UTF-8 BOM on the first header field should not cause a confusing
+    /// "missing column `sample_id`" error.
+    #[test]
+    fn test_header_with_utf8_bom_is_handled() {
+        let lines = vec![
+            format!("\u{FEFF}{}", Sample::deserialize_header_line()),
+            "sample1\tGATTACA".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let group = SampleGroup::from_file(&f1, &[]).unwrap();
+        assert_eq!(group.samples[0].sample_id, "sample1");
+        assert_eq!(group.samples[0].barcode, "GATTACA");
+    }
+
+    /// CRLF line endings on a row should not cause the trailing `\r` to bleed into the
+    /// barcode column and break downstream validation.
+    #[test]
+    fn test_rows_with_crlf_endings_are_handled() {
+        let header = format!("{}\r", Sample::deserialize_header_line());
+        let lines = vec![header, "sample1\tGATTACA\r".to_owned(), "sample2\tCATGCTA\r".to_owned()];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let group = SampleGroup::from_file(&f1, &[]).unwrap();
+        assert_eq!(group.samples[0].barcode, "GATTACA");
+        assert_eq!(group.samples[1].barcode, "CATGCTA");
+    }
+
+    /// `matching_prefix_lens` must error (not panic) when a sample's per-sample read
+    /// structure count differs from `default_structures.len()`.
+    #[test]
+    fn test_matching_prefix_lens_errors_on_rs_count_mismatch() {
+        // Sample declares two read structures; defaults provide only one.
+        let s1 = sample_with_rs("S1", "GATTACAGGGGGGG", &["3M7B1S+T", "7B+T"]);
+        let group = SampleGroup::from_samples(&[s1]);
+        let defaults = vec![make_rs("3M7B+T")];
+        let err = group.matching_prefix_lens(&defaults).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("number of read structures") && msg.contains("number of inputs"),
+            "got: {msg}",
+        );
+    }
+
+    /// Non-contiguous `read_structure_<n>` columns must error.
+    #[test]
+    fn test_per_sample_columns_must_be_contiguous() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_1\tread_structure_3".to_owned(),
+            "S1\tGATTACA\t3M7B1S+T\t1S7B+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T"), make_rs("7B+T")];
+        let err = SampleGroup::from_file(&f1, &globals).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("contiguous"), "got: {msg}");
+    }
+
+    /// A non-integer suffix on a `read_structure_<n>` column must error.
+    #[test]
+    fn test_per_sample_columns_must_have_integer_suffix() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_abc".to_owned(),
+            "S1\tGATTACA\t3M7B1S+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T")];
+        let err = SampleGroup::from_file(&f1, &globals).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("non-integer suffix"), "got: {msg}");
+    }
+
+    /// A zero-indexed `read_structure_0` column must error since indexing is 1-based.
+    #[test]
+    fn test_per_sample_columns_must_be_one_indexed() {
+        let lines = vec![
+            "sample_id\tbarcode\tread_structure_0".to_owned(),
+            "S1\tGATTACA\t3M7B1S+T".to_owned(),
+        ];
+        let tempdir = TempDir::new().unwrap();
+        let f1 = write_metadata(&tempdir, &lines);
+        let globals = vec![make_rs("3M7B+T")];
+        let err = SampleGroup::from_file(&f1, &globals).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("1-based indexing"), "got: {msg}");
     }
 }


### PR DESCRIPTION
Closes #81.

## Summary

Adds optional `read_structure_<n>` columns to the sample metadata TSV (one per input FASTQ). When any sample declares them, they replace the global `--read-structures` for that sample, both for matching-pattern construction and for output extraction. The legacy code path is unchanged when no per-sample structures are declared.

The motivating case is CODEC ([Bae et al. 2023](https://www.nature.com/articles/s41588-023-01376-0), [CODECsuite](https://github.com/broadinstitute/CODECsuite)), where the position of the constant ligation base shifts per sample due to staggered inline indices. See [nf-core/fastquorum#139 (comment)](https://github.com/nf-core/fastquorum/issues/139#issuecomment-4318518405) for context.

## Design

1. **Metadata parsing.** `samples.rs` hand-parses the TSV header so it can pick up an arbitrary number of `read_structure_<n>` columns. The parser keeps backward compatibility with the existing two-column format. Per-sample read structures are all-or-none at the column level: either no `read_structure_<n>` columns exist (legacy), or they exist and apply per sample. A blank cell falls back to `globals[i]` for that input, and a row whose cells are all blank uses the globals entirely (a "global-only" sample). Per-sample structures may differ in their per-input `(T, B, M, C)` segment counts across samples — each sample writes its own set of output files — but the concatenated `B`-segment length must equal the `barcode` column for every sample. `SampleGroup::from_samples` returns `Result` so malformed metadata surfaces a clean error rather than panicking.

2. **Matching window.** For each input FASTQ, the matching window length is the maximum across samples of the offset of the first `Template` segment. Each sample's expected pattern is built by walking its own read structure: `B`-segment positions are filled from the `barcode` column (taken in order across inputs), and `M`/`S`/`C` positions and any trailing positions up to the window are filled with `N` (treated as wildcards by the existing matcher).

3. **Matching.** `BarcodeMatcher` gains a `with_patterns` constructor that takes pre-built per-sample patterns alongside the samples. The existing `new` is kept (now a thin wrapper around `with_patterns`).

4. **Output extraction.** `ReadSet` optionally carries the raw bases / quals from each input so the iterator's eager segmentation can be replaced after match assignment. When a read matches a sample with per-sample structures, `ReadSet::resegment` produces a fresh `ReadSet` whose segments are extracted from raw bases according to the matched sample's read structure. This preserves the template intact for shorter-stagger samples (no template haircut; `BC` tag is exactly the index). When per-sample structures are not in use, the old eager-segmentation path runs unchanged and `raw_per_input` stays empty.

5. **Sample writer setup.** `create_writers` uses each sample's per-sample structure (where present) to decide how many output files of each type to open, so e.g. an extra `M` segment in one sample's structure isn't silently dropped. The unmatched pseudo-sample uses the global `--read-structures`.

## Behavior note (please read)

Because the iterator gate in per-sample mode is loosened to the per-sample matching-window length (a global `min_len` would over-reject reads that satisfy a sample's shorter structure), a read can clear the gate and then be too short for the full structure when re-segmented. This is now handled consistently across all three code paths — matched, unmatched, and legacy:

- **With `--skip-reasons too-few-bases`:** the read is counted as a `TooFewBases` skip and the run continues.
- **Without it:** the run aborts with an error that names `--skip-reasons too-few-bases` as the remedy.

This is a deliberate change from an earlier revision, where a too-short read on the *unmatched* path was always skipped regardless of `--skip-reasons` (inconsistent with the matched/legacy paths). Reviewers who run per-sample demux on data with many short, unassignable reads (e.g. adapter dimers) should pass `--skip-reasons too-few-bases` to tolerate them.

Relatedly, a read whose bases end exactly at the start of a variable-length template (`+T`) has zero template bases; the underlying `read-structure` crate returns an empty slice rather than an error, which would have written a zero-length FASTQ record. `resegment` now treats this as `TooShort` so no empty records are emitted.

## Validation & error messages

Per-sample metadata is validated up front with actionable messages:

- All sample-barcode (`B`) segments must precede the template (`T`); a `B` after the template can never be matched.
- The effective read structure's total `B` length must equal the `barcode` column for every sample — including global-only samples in mixed mode, whose effective structure is the `--read-structures` fallback.
- Pre-template segments must be fixed length; a variable-length pre-template segment reports the offending read structure and explains the fixed-window requirement.

## Tests

- 42 unit tests in `samples.rs` covering pattern construction, validation rules (B-before-T, effective barcode length, fixed-window), dual-input concatenation, per-cell fallback to globals, and `from_file` error handling.
- End-to-end `test_demux_codec_per_sample_read_structures_paired_end` exercises the CODEC stagger case (S1 `3M7B1S+T`, S2 `3M1S7B1S+T`) and verifies template / `BC` / UMI outputs for both inputs of both samples.
- `test_demux_codec_per_sample_single_input` covers the common single-input inline-index layout with two different staggers and guards against template haircut for the shorter-stagger sample.
- Unmatched-too-short behavior is covered both ways: aborts without the flag (error names the remedy) and skips with it.
- Zero-length-template boundary covered at the `resegment` unit level and end-to-end through `execute`.

`cargo test` totals **168** (88 lib + 67 bin + 13 doc).

## Limitations / follow-ups

- `S` segments are wildcards in the matching pattern, so the constant ligation base (the "trailing T" anchor for CODEC) is not validated at match time. In practice the `B` segments dominate the mismatch budget, so this is fine, but a follow-up could add an optional column for expected `S`-segment bases to recover the anchor.
- Only the last segment may be variable-length (`+T`); intermediate variable-length segments aren't supported (matches the `read-structure` crate constraint).
- Per-sample structures must have one entry per input FASTQ (blank cells fall back to the corresponding global). There is no way to add or remove inputs per sample.

## Test plan

- [x] `cargo test` (lib + bin + doc-tests, 168 tests total)
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --release`
- [ ] Run on a real CODEC FASTQ (reviewer)
