### PR TITLE
subsample: apply shard's read-ahead decompression + robust shutdown

### DIFF
--- a/src/bin/commands/fastq_readahead.rs
+++ b/src/bin/commands/fastq_readahead.rs
@@ -1,0 +1,158 @@
+//! Background-decompressing FASTQ input readers shared across subcommands.
+//!
+//! Splits gzip inflation off the consuming thread: for each input, a background read-ahead thread
+//! decompresses the file into fixed-size byte chunks ([`ByteChunker`]), and the returned readers
+//! parse records from those bytes on the consuming (main) thread ([`ChunkReader`]).  Keeping
+//! inflation off the main thread leaves it free to parse records and route them downstream (e.g.
+//! to a compression pool).
+
+use anyhow::Result;
+use fgoxide::io::Io;
+use fgoxide::iter::{ChunkedReadAheadIterator, IntoChunkedReadAheadIterator};
+use seq_io::fastq::Reader as FastqReader;
+use std::cmp::min;
+use std::io::{self, BufRead, Read};
+use std::path::PathBuf;
+
+/// Buffer size used when opening BufReads for input files and sizing the FASTQ parser.
+const BUFFER_SIZE: usize = 1024 * 1024;
+
+/// Default size, in bytes, of each decompressed input chunk handed from the decompression thread
+/// to the consuming thread.
+const DEFAULT_CHUNK_SIZE: usize = 128 * 1024;
+
+/// Default number of decompressed input chunks kept in flight on the read-ahead thread.
+const DEFAULT_CHUNK_COUNT: usize = 32;
+
+/// A decompressed chunk of input bytes shuttled from a decompression thread to the consuming
+/// (parsing) thread, or an I/O error encountered while decompressing.
+type ByteChunk = io::Result<Vec<u8>>;
+
+/// Read-ahead stream of decompressed input byte chunks produced on a background thread.
+type ByteChunkStream = ChunkedReadAheadIterator<ByteChunk>;
+
+/// Builds a single background-decompressing FASTQ reader for one input file.
+///
+/// Construct with the input `path` and, optionally, override `chunk_size`/`chunk_count`; the
+/// `Default` impl supplies sensible values for the latter two, so the common case is:
+///
+/// ```ignore
+/// let reader = ReadAheadBuilder { path, ..Default::default() }.build()?;
+/// ```
+pub(crate) struct ReadAheadBuilder {
+    /// Path to the input FASTQ (may be uncompressed, gzipped, or block-gzipped).
+    pub(crate) path: PathBuf,
+    /// Target size, in bytes, of each decompressed chunk handed to the consuming thread.
+    pub(crate) chunk_size: usize,
+    /// Number of decompressed chunks kept in flight on the read-ahead thread.
+    pub(crate) chunk_count: usize,
+}
+
+impl ReadAheadBuilder {
+    /// Opens the input and returns a FASTQ reader that parses records on the consuming thread
+    /// while a background read-ahead thread decompresses the file into fixed-size byte chunks.
+    /// This keeps gzip inflation off the consuming thread, leaving it free to parse and route
+    /// records.
+    pub(crate) fn build(self) -> Result<FastqReader<ChunkReader>> {
+        let decompressed = Io::new(5, BUFFER_SIZE).new_reader(&self.path)?;
+        let chunker =
+            ByteChunker { reader: decompressed, chunk_size: self.chunk_size, done: false };
+        let chunks = chunker.read_ahead(1, self.chunk_count);
+        let chunk_reader = ChunkReader { chunks, current: Vec::new(), pos: 0 };
+        Ok(FastqReader::with_capacity(chunk_reader, BUFFER_SIZE))
+    }
+}
+
+impl Default for ReadAheadBuilder {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::new(),
+            chunk_size: DEFAULT_CHUNK_SIZE,
+            chunk_count: DEFAULT_CHUNK_COUNT,
+        }
+    }
+}
+
+/// Iterator that reads fixed-size chunks of decompressed bytes from an input reader.
+///
+/// The wrapped reader decompresses lazily as it is read, so running this iterator on a
+/// background (read-ahead) thread keeps gzip inflation off the consuming thread.  Each chunk ends
+/// on an arbitrary byte boundary; records that span two chunks are stitched back together
+/// downstream by [`ChunkReader`] before `seq_io` parses them.
+struct ByteChunker {
+    /// The decompressing input reader.
+    reader: Box<dyn BufRead + Send>,
+    /// Target size, in bytes, of each emitted chunk.
+    chunk_size: usize,
+    /// Set once the underlying reader is exhausted or has errored.
+    done: bool,
+}
+
+impl Iterator for ByteChunker {
+    type Item = ByteChunk;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        // Fill a fresh buffer as fully as possible; a single `read` on a decompressing reader
+        // often returns less than requested, so loop until full or the input is exhausted.
+        let mut buf = vec![0u8; self.chunk_size];
+        let mut filled = 0;
+        while filled < self.chunk_size {
+            match self.reader.read(&mut buf[filled..]) {
+                Ok(0) => break,
+                Ok(n) => filled += n,
+                Err(e) => {
+                    self.done = true;
+                    return Some(Err(e));
+                }
+            }
+        }
+        if filled == 0 {
+            self.done = true;
+            None
+        } else {
+            buf.truncate(filled);
+            Some(Ok(buf))
+        }
+    }
+}
+
+/// A [`Read`] adapter over a [`ByteChunkStream`] that serves the decompressed bytes received
+/// from the decompression thread.  This is the seam that lets FASTQ parsing run on the consuming
+/// thread while decompression runs upstream.
+pub(crate) struct ChunkReader {
+    /// The stream of decompressed byte chunks from the decompression thread.
+    chunks: ByteChunkStream,
+    /// The chunk currently being served from.
+    current: Vec<u8>,
+    /// Offset of the next unserved byte within `current`.
+    pos: usize,
+}
+
+impl Read for ChunkReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Per the `Read` contract a zero-length buffer must return `Ok(0)` without consuming
+        // input; without this guard the loop below could block fetching the next chunk.
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        loop {
+            if self.pos < self.current.len() {
+                let n = min(buf.len(), self.current.len() - self.pos);
+                buf[..n].copy_from_slice(&self.current[self.pos..self.pos + n]);
+                self.pos += n;
+                return Ok(n);
+            }
+            match self.chunks.next() {
+                Some(Ok(chunk)) => {
+                    self.current = chunk;
+                    self.pos = 0;
+                }
+                Some(Err(e)) => return Err(e),
+                None => return Ok(0),
+            }
+        }
+    }
+}

--- a/src/bin/commands/fastq_readahead.rs
+++ b/src/bin/commands/fastq_readahead.rs
@@ -54,7 +54,9 @@ impl ReadAheadBuilder {
     /// This keeps gzip inflation off the consuming thread, leaving it free to parse and route
     /// records.
     pub(crate) fn build(self) -> Result<FastqReader<ChunkReader>> {
-        let decompressed = Io::new(5, BUFFER_SIZE).new_reader(&self.path)?;
+        let decompressed = Io::new(5, BUFFER_SIZE)
+            .new_reader(&self.path)
+            .map_err(|e| anyhow::anyhow!("Failed to open {:?}: {e}", self.path))?;
         let chunker =
             ByteChunker { reader: decompressed, chunk_size: self.chunk_size, done: false };
         let chunks = chunker.read_ahead(1, self.chunk_count);

--- a/src/bin/commands/mod.rs
+++ b/src/bin/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod command;
 pub mod demux;
+pub mod fastq_readahead;
 pub mod shard;
 pub mod subsample;

--- a/src/bin/commands/shard.rs
+++ b/src/bin/commands/shard.rs
@@ -1,115 +1,15 @@
 use crate::commands::command::Command;
+use crate::commands::fastq_readahead::ReadAheadBuilder;
 use anyhow::{Result, anyhow};
 use clap::Parser;
 use clap::builder::RangedU64ValueParser;
-use fgoxide::io::Io;
-use fgoxide::iter::{ChunkedReadAheadIterator, IntoChunkedReadAheadIterator};
 use itertools::Itertools;
 use log::info;
 use pooled_writer::{Pool, PoolBuilder, PooledWriter, bgzf::BgzfCompressor};
 use proglog::{CountFormatterKind, ProgLogBuilder};
-use seq_io::fastq::Reader as FastqReader;
-use std::cmp::min;
 use std::fs::File;
-use std::io::{self, BufRead, BufWriter, Read, Write};
+use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
-
-/// Buffer size used when opening BufReads for input files
-const BUFFER_SIZE: usize = 1024 * 1024;
-
-/// A decompressed chunk of input bytes shuttled from a decompression thread to the main
-/// (parsing) thread, or an I/O error encountered while decompressing.
-type ByteChunk = io::Result<Vec<u8>>;
-
-/// Read-ahead stream of decompressed input byte chunks produced on a background thread.
-type ByteChunkStream = ChunkedReadAheadIterator<ByteChunk>;
-
-/// A FASTQ reader whose records are parsed on the consuming thread from a [`ByteChunkStream`].
-type InputReader = FastqReader<ChunkReader>;
-
-/// Iterator that reads fixed-size chunks of decompressed bytes from an input reader.
-///
-/// The wrapped reader decompresses lazily as it is read, so running this iterator on a
-/// background (read-ahead) thread keeps gzip inflation off the main thread.  Each chunk ends on
-/// an arbitrary byte boundary; records that span two chunks are stitched back together
-/// downstream by [`ChunkReader`] before `seq_io` parses them.
-struct ByteChunker {
-    /// The decompressing input reader.
-    reader: Box<dyn BufRead + Send>,
-    /// Target size, in bytes, of each emitted chunk.
-    chunk_size: usize,
-    /// Set once the underlying reader is exhausted or has errored.
-    done: bool,
-}
-
-impl Iterator for ByteChunker {
-    type Item = ByteChunk;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
-        }
-        // Fill a fresh buffer as fully as possible; a single `read` on a decompressing reader
-        // often returns less than requested, so loop until full or the input is exhausted.
-        let mut buf = vec![0u8; self.chunk_size];
-        let mut filled = 0;
-        while filled < self.chunk_size {
-            match self.reader.read(&mut buf[filled..]) {
-                Ok(0) => break,
-                Ok(n) => filled += n,
-                Err(e) => {
-                    self.done = true;
-                    return Some(Err(e));
-                }
-            }
-        }
-        if filled == 0 {
-            self.done = true;
-            None
-        } else {
-            buf.truncate(filled);
-            Some(Ok(buf))
-        }
-    }
-}
-
-/// A [`Read`] adapter over a [`ByteChunkStream`] that serves the decompressed bytes received
-/// from the decompression thread.  This is the seam that lets FASTQ parsing run on the consuming
-/// thread while decompression runs upstream.
-struct ChunkReader {
-    /// The stream of decompressed byte chunks from the decompression thread.
-    chunks: ByteChunkStream,
-    /// The chunk currently being served from.
-    current: Vec<u8>,
-    /// Offset of the next unserved byte within `current`.
-    pos: usize,
-}
-
-impl Read for ChunkReader {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        // Per the `Read` contract a zero-length buffer must return `Ok(0)` without consuming
-        // input; without this guard the loop below could block fetching the next chunk.
-        if buf.is_empty() {
-            return Ok(0);
-        }
-        loop {
-            if self.pos < self.current.len() {
-                let n = min(buf.len(), self.current.len() - self.pos);
-                buf[..n].copy_from_slice(&self.current[self.pos..self.pos + n]);
-                self.pos += n;
-                return Ok(n);
-            }
-            match self.chunks.next() {
-                Some(Ok(chunk)) => {
-                    self.current = chunk;
-                    self.pos = 0;
-                }
-                Some(Err(e)) => return Err(e),
-                None => return Ok(0),
-            }
-        }
-    }
-}
 
 /// Holds the set of output writers for a single shard, one per input FASTQ.
 struct ShardWriters<W: Write> {
@@ -195,26 +95,6 @@ pub(crate) struct Shard {
 }
 
 impl Shard {
-    /// Opens one FASTQ reader per input path, splitting decompression and parsing across threads.
-    ///
-    /// For each input, a background read-ahead thread decompresses the file into fixed-size byte
-    /// chunks (sized by `--chunk-size`, with `--chunk-count` chunks in flight); the returned
-    /// readers parse those bytes into records on the consuming thread.  This keeps gzip inflation
-    /// off the main thread, leaving it free to parse and route records to the compression pool.
-    fn build_record_readers(&self) -> Result<Vec<InputReader>> {
-        let fgio = Io::new(5, BUFFER_SIZE);
-        let mut readers = Vec::with_capacity(self.inputs.len());
-        for path in &self.inputs {
-            let decompressed = fgio.new_reader(path)?;
-            let chunker =
-                ByteChunker { reader: decompressed, chunk_size: self.chunk_size, done: false };
-            let chunks = chunker.read_ahead(1, self.chunk_count);
-            let chunk_reader = ChunkReader { chunks, current: Vec::new(), pos: 0 };
-            readers.push(FastqReader::with_capacity(chunk_reader, BUFFER_SIZE));
-        }
-        Ok(readers)
-    }
-
     /// Builds the fastq writers for each output file and shard, and then instantiates
     /// a writer pool using block-gzip compression.  Returns the writer Pool itself along
     /// with a Vec of `ShardWriters` each of which can accept and write `Vec`s of fastq records
@@ -270,7 +150,17 @@ impl Command for Shard {
         // input and hands decompressed byte chunks to these readers, which parse records here on
         // the main thread.  Keeping inflation off the main thread lets it spend its time parsing
         // and routing records to keep the compression pool fed.
-        let mut readers = self.build_record_readers()?;
+        let mut readers = Vec::with_capacity(self.inputs.len());
+        for path in &self.inputs {
+            readers.push(
+                ReadAheadBuilder {
+                    path: path.clone(),
+                    chunk_size: self.chunk_size,
+                    chunk_count: self.chunk_count,
+                }
+                .build()?,
+            );
+        }
         let n_inputs = readers.len();
 
         let (mut pool, mut shard_writers) = self.build_writer_pool()?;

--- a/src/bin/commands/subsample.rs
+++ b/src/bin/commands/subsample.rs
@@ -232,8 +232,8 @@ impl Command for Subsample {
 
                 // Pull one record from each input *before* writing any of them, mirroring shard.
                 // Validating the whole set up front means a failure partway through a set (read
-                // error, premature EOF, or read-name mismatch) is surfaced without leaving a
-                // half-written, misaligned set in the output files.
+                // error or premature EOF) is surfaced without leaving a half-written, misaligned
+                // set in the output files.
                 let records: Vec<_> = sources.iter_mut().map(|source| source.next()).collect();
 
                 for result in records.iter().flatten() {
@@ -255,27 +255,28 @@ impl Command for Subsample {
                     ));
                 }
 
-                if check_names {
-                    for (i, slot) in records.iter().enumerate() {
-                        if let Some(Ok(rec)) = slot {
-                            let name = base_read_name(rec.head());
-                            if i == 0 {
-                                expected_name.clear();
-                                expected_name.extend_from_slice(name);
-                            } else if name != expected_name.as_slice() {
-                                break 'process Err(anyhow::anyhow!(
-                                    "Read name mismatch at read {}: file 0={:?}, file {i}={:?}",
-                                    total_read + 1,
-                                    String::from_utf8_lossy(&expected_name),
-                                    String::from_utf8_lossy(name),
-                                ));
+                // Read-name checking and writing happen only for kept sets.  The name check still
+                // runs before any write so a mismatch can't leave a half-written, misaligned set.
+                if keep {
+                    if check_names {
+                        for (i, slot) in records.iter().enumerate() {
+                            if let Some(Ok(rec)) = slot {
+                                let name = base_read_name(rec.head());
+                                if i == 0 {
+                                    expected_name.clear();
+                                    expected_name.extend_from_slice(name);
+                                } else if name != expected_name.as_slice() {
+                                    break 'process Err(anyhow::anyhow!(
+                                        "Read name mismatch at read {}: file 0={:?}, file {i}={:?}",
+                                        total_read + 1,
+                                        String::from_utf8_lossy(&expected_name),
+                                        String::from_utf8_lossy(name),
+                                    ));
+                                }
                             }
                         }
                     }
-                }
 
-                // Only after the whole set is validated do we write the kept records.
-                if keep {
                     for (slot, writer) in records.iter().zip(writers.iter_mut()) {
                         if let Some(Ok(rec)) = slot {
                             if let Err(e) = rec.write_unchanged(&mut *writer) {

--- a/src/bin/commands/subsample.rs
+++ b/src/bin/commands/subsample.rs
@@ -1,21 +1,18 @@
 use crate::commands::command::Command;
-use anyhow::{Result, ensure};
+use crate::commands::fastq_readahead::ReadAheadBuilder;
+use anyhow::Result;
 use clap::Parser;
-use fgoxide::io::Io;
 use log::info;
 use pooled_writer::{Pool, PoolBuilder, PooledWriter, bgzf::BgzfCompressor};
 use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use seq_io::fastq::Reader as FastqReader;
 use seq_io::fastq::Record;
 use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
-use std::io::{BufRead, BufWriter};
+use std::io::BufWriter;
 use std::path::PathBuf;
-
-const BUFFER_SIZE: usize = 1024 * 1024;
 
 /// Formats a u64 with comma separators (e.g. 1,234,567).
 fn fmt_count(n: u64) -> String {
@@ -199,17 +196,14 @@ impl Command for Subsample {
         info!("Using random seed: {}", seed);
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
-        // Open input FASTQ readers
-        let fgio = Io::new(5, BUFFER_SIZE);
-        let mut sources: Vec<FastqReader<Box<dyn BufRead + Send>>> = self
-            .inputs
-            .iter()
-            .map(|p| {
-                fgio.new_reader(p)
-                    .map(|r| FastqReader::with_capacity(r, BUFFER_SIZE))
-                    .map_err(|e| anyhow::anyhow!("Failed to open {p:?}: {e}"))
-            })
-            .collect::<Result<Vec<_>>>()?;
+        // Open one reader per input.  Decompression runs on a background read-ahead thread per
+        // input and hands decompressed byte chunks to these readers, which parse records here on
+        // the main thread.  Keeping inflation off the main thread leaves it free to parse records
+        // and run the per-record RNG draw and read-name sync checks.
+        let mut sources = Vec::with_capacity(self.inputs.len());
+        for path in &self.inputs {
+            sources.push(ReadAheadBuilder { path: path.clone(), ..Default::default() }.build()?);
+        }
 
         // Create output writers
         let (mut pool, mut writers) = self.create_writers()?;
@@ -228,69 +222,94 @@ impl Command for Subsample {
         let mut total_read: u64 = 0;
         let mut total_kept: u64 = 0;
 
-        loop {
-            let keep = rng.random::<f64>() < self.fraction;
-            let mut records_found = 0usize;
+        // Process records in lockstep across all inputs.  The result is captured rather than
+        // returned directly so the writer pool is always shut down afterwards (below), even on
+        // error -- flushing queued output and surfacing any finalization error instead of leaving
+        // it to a panicking drop.  A processing error takes precedence over a cleanup error.
+        let process_result: Result<()> = 'process: {
+            loop {
+                let keep = rng.random::<f64>() < self.fraction;
 
-            for (i, source) in sources.iter_mut().enumerate() {
-                if let Some(result) = source.next() {
-                    let rec = result?;
-                    records_found += 1;
+                // Pull one record from each input *before* writing any of them, mirroring shard.
+                // Validating the whole set up front means a failure partway through a set (read
+                // error, premature EOF, or read-name mismatch) is surfaced without leaving a
+                // half-written, misaligned set in the output files.
+                let records: Vec<_> = sources.iter_mut().map(|source| source.next()).collect();
 
-                    if keep {
-                        if check_names {
+                for result in records.iter().flatten() {
+                    if let Err(e) = result {
+                        break 'process Err(anyhow::anyhow!("Error reading FASTQ input: {e}"));
+                    }
+                }
+
+                let records_found = records.iter().filter(|slot| slot.is_some()).count();
+                if records_found == 0 {
+                    break; // all inputs exhausted together: a clean end of input
+                }
+                if records_found != num_inputs {
+                    break 'process Err(anyhow::anyhow!(
+                        "FASTQ files are out of sync: {} of {} files had a record at read {}",
+                        records_found,
+                        num_inputs,
+                        total_read + 1,
+                    ));
+                }
+
+                if check_names {
+                    for (i, slot) in records.iter().enumerate() {
+                        if let Some(Ok(rec)) = slot {
                             let name = base_read_name(rec.head());
                             if i == 0 {
                                 expected_name.clear();
                                 expected_name.extend_from_slice(name);
                             } else if name != expected_name.as_slice() {
-                                anyhow::bail!(
+                                break 'process Err(anyhow::anyhow!(
                                     "Read name mismatch at read {}: file 0={:?}, file {i}={:?}",
                                     total_read + 1,
                                     String::from_utf8_lossy(&expected_name),
                                     String::from_utf8_lossy(name),
-                                );
+                                ));
                             }
                         }
-
-                        rec.write_unchanged(&mut writers[i])?;
                     }
                 }
-            }
 
-            if records_found == 0 {
-                break;
-            }
+                // Only after the whole set is validated do we write the kept records.
+                if keep {
+                    for (slot, writer) in records.iter().zip(writers.iter_mut()) {
+                        if let Some(Ok(rec)) = slot {
+                            if let Err(e) = rec.write_unchanged(&mut *writer) {
+                                break 'process Err(e.into());
+                            }
+                        }
+                    }
+                }
 
-            ensure!(
-                records_found == num_inputs,
-                "FASTQ files are out of sync: {} of {} files had a record at read {}",
-                records_found,
-                num_inputs,
-                total_read + 1,
-            );
-
-            total_read += 1;
-            if keep {
-                total_kept += 1;
+                total_read += 1;
+                if keep {
+                    total_kept += 1;
+                }
+                if total_read % log_unit == 0 {
+                    let pct = total_kept as f64 / total_read as f64 * 100.0;
+                    info!(
+                        "[fqtk subsample] Read {} record sets and wrote {} ({:.1}%).",
+                        fmt_count(total_read),
+                        fmt_count(total_kept),
+                        pct,
+                    );
+                }
             }
-            if total_read % log_unit == 0 {
-                let pct = total_kept as f64 / total_read as f64 * 100.0;
-                info!(
-                    "[fqtk subsample] Read {} record sets and wrote {} ({:.1}%).",
-                    fmt_count(total_read),
-                    fmt_count(total_kept),
-                    pct,
-                );
-            }
-        }
+            Ok(())
+        };
 
-        // Shut down writers and pool
+        // Always shut the pool down so queued output is flushed and any finalization error is
+        // propagated, regardless of whether record processing succeeded.  A processing error
+        // takes precedence over a cleanup error.
         info!("Finished reading input FASTQs.");
-        for writer in writers {
-            writer.close()?;
-        }
-        pool.stop_pool()?;
+        let close_result =
+            writers.into_iter().try_for_each(PooledWriter::close).map_err(anyhow::Error::from);
+        let stop_result = pool.stop_pool().map_err(anyhow::Error::from);
+        process_result.and(close_result).and(stop_result)?;
 
         let pct = if total_read > 0 { total_kept as f64 / total_read as f64 * 100.0 } else { 0.0 };
         info!(
@@ -307,7 +326,9 @@ impl Command for Subsample {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fgoxide::io::Io;
     use seq_io::fastq::OwnedRecord;
+    use seq_io::fastq::Reader as FastqReader;
     use tempfile::TempDir;
 
     /// Creates FASTQ content lines from the given read name prefix and base sequences.
@@ -837,5 +858,44 @@ mod tests {
         };
         // Should succeed with name checking disabled
         cmd.execute().unwrap();
+    }
+
+    /// When paired inputs have different lengths the run must error *and* must not leave a
+    /// half-written, misaligned set: the kept R1/R2 outputs must hold equal record counts (the
+    /// orphan record from the longer input must not have been written before the error).
+    #[test]
+    fn test_out_of_sync_inputs_leave_no_orphan_record() {
+        let tmp = TempDir::new().unwrap();
+        // Same read names so the name check passes; R1 has one extra record so the third set is
+        // out of sync.  At fraction 1.0 every in-sync set is kept, so without validate-before-write
+        // the orphan R1 record would be emitted before the mismatch is detected.
+        let lines_r1 = fq_lines_from_bases("r", &make_bases(3));
+        let lines_r2 = fq_lines_from_bases("r", &make_bases(2));
+        let input_r1 = write_fastq(&tmp, "r1", &lines_r1);
+        let input_r2 = write_fastq(&tmp, "r2", &lines_r2);
+        let output = tmp.path().join("out");
+
+        let cmd = Subsample {
+            inputs: vec![input_r1, input_r2],
+            output: output.clone(),
+            fraction: 1.0,
+            threads: 2,
+            compression_level: 1,
+            seed: Some(42),
+            disable_read_name_checking: false,
+        };
+        let err = cmd.execute().unwrap_err();
+        assert!(err.to_string().contains("out of sync"), "unexpected error: {err}");
+
+        let r1 = read_fastq(&PathBuf::from(format!("{}.R1.fq.gz", output.display())));
+        let r2 = read_fastq(&PathBuf::from(format!("{}.R2.fq.gz", output.display())));
+        assert_eq!(
+            r1.len(),
+            r2.len(),
+            "R1/R2 outputs left misaligned on the out-of-sync error path"
+        );
+        // The two in-sync pairs must be kept (fraction 1.0) and only the orphan third read
+        // rejected -- guards against the assertion passing vacuously if both outputs were empty.
+        assert_eq!(r1.len(), 2, "expected the two in-sync pairs to be preserved");
     }
 }


### PR DESCRIPTION
Applied the following learnings from the shard command work to `subsample`:

- **Background-decompression read-ahead.** Extracted shard's per-input
  inflate-off-the-main-thread machinery (`ByteChunker` → read-ahead thread →
  `ChunkReader`) into a shared `fastq_readahead` module and routed `subsample`'s
  input through it, so gzip inflation no longer competes with parsing, the
  per-record RNG draw, and read-name sync checks on the main thread.
- **Robust writer-pool shutdown on error.** `subsample::execute` now captures the
  processing result and always closes the writers and stops the pool, even on a
  mid-stream error — flushing queued output and surfacing finalization errors
  instead of leaving them to a panicking drop. A processing error takes precedence
  over a cleanup error. (Mirrors the fix CodeRabbit prompted for shard.)
- **Zero-length-read guard** in `ChunkReader::read`, per the `Read` contract, so
  the shared reader can't block on an empty buffer. Benefits both commands.

Shared module shape: a `ReadAheadBuilder { path, ..Default::default() }.build()`
returning one reader; callers loop over inputs.

Targets `tf_shard` (not `main`) because the extracted machinery and shard's use of
it only exist on that branch. When `tf_shard` merges (squashed), this will need a
rebase onto `main`.
