### PR TITLE
docs: point Zenodo DOI badge at the concept DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img src="https://img.shields.io/crates/l/fqtk.svg" alt="license">
   <a href="https://crates.io/crates/fqtk"><img src="https://img.shields.io/crates/v/fqtk.svg?colorB=319e8c" alt="Version info"></a>
   <a href="http://bioconda.github.io/recipes/fqtk/README.html"><img src="https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat" alt="Install with bioconda"></a>
-  <a href="https://doi.org/10.5281/zenodo.13345414"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.13345414.svg" alt="DOI"></a>
+  <a href="https://doi.org/10.5281/zenodo.13345413"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.13345413.svg" alt="DOI"></a>
   <br>
 </p>
 


### PR DESCRIPTION
The DOI badge referenced `10.5281/zenodo.13345414`, a version DOI pinned to `v0.3.1`. That is the current release, so the badge is accurate today — but it would silently freeze at `v0.3.1` as soon as the next release is cut.

This switches the badge to `10.5281/zenodo.13345413`, the concept DOI covering all versions, which always resolves to the latest release.

Verified: both DOIs currently resolve to `fulcrumgenomics/fqtk: v0.3.1`; `13345413` is the concept DOI of that record.
