### PR TITLE
docs: correct `fqtk demux --threads` minimum in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Options:
           [default: 2]
 
   -t, --threads <THREADS>
-          The number of threads to use. Cannot be less than 3
+          The number of threads to use. Cannot be less than 5
 
           [default: 8]
 

--- a/src/bin/commands/demux.rs
+++ b/src/bin/commands/demux.rs
@@ -932,7 +932,7 @@ pub(crate) struct Demux {
     #[clap(long, short = 'd', default_value = "2")]
     min_mismatch_delta: usize,
 
-    /// The number of threads to use. Cannot be less than 3.
+    /// The number of threads to use. Cannot be less than 5.
     #[clap(long, short = 't', default_value = "8")]
     threads: usize,
 
@@ -1778,9 +1778,12 @@ mod tests {
         demux_inputs.execute().unwrap();
     }
 
-    #[test]
-    #[should_panic(expected = "Threads provided 2 was too low!")]
-    fn test_too_few_threads_fails() {
+    /// Demultiplexing needs one main thread, one read-ahead thread, and three writer threads, so
+    /// four threads is the boundary case just below the minimum.
+    #[rstest]
+    #[case(2)]
+    #[case(4)]
+    fn test_too_few_threads_fails(#[case] threads: usize) {
         let tmp = TempDir::new().unwrap();
         let read_structures = vec![
             ReadStructure::from_str("+T").unwrap(),
@@ -1806,12 +1809,18 @@ mod tests {
             unmatched_prefix: "unmatched".to_owned(),
             max_mismatches: 1,
             min_mismatch_delta: 2,
-            threads: 2,
+            threads,
             compression_level: 5,
             skip_reasons: vec![],
             template_types: vec!['T'],
         };
-        demux_inputs.execute().unwrap();
+        let message = demux_inputs.execute().expect_err("demux unexpectedly succeeded").to_string();
+        assert!(
+            message.contains(&format!("Threads provided {} was too low!", threads)),
+            "unexpected error message for {} threads: {}",
+            threads,
+            message
+        );
     }
 
     #[test]


### PR DESCRIPTION
The `--threads` help text for `fqtk demux` has claimed *"Cannot be less than 3"* since the initial commit, but validation actually rejects anything below 5:

```rust
/// The number of threads to use. Cannot be less than 3.
#[clap(long, short = 't', default_value = "8")]
threads: usize,
```
```rust
if self.threads < 5 {
    constraint_errors
        .push(format!("Threads provided {} was too low! Must be 5 or more.", self.threads));
}
```

So `fqtk demux -t 3` and `-t 4` are accepted by the documented contract but fail at runtime with a validation error.

## Where it came from

Both numbers were 3 originally. #19 ("Integrate read ahead iterator from fgoxide") raised the floor to 5 and the default from 3 to 8 — because it added a second reader thread — but left the doc comment alone. The floor of 5 matches the thread budgeting in `execute`: 1 main thread + 1 read-ahead thread + 3 writer threads.

## Changes

- Correct the doc comment to say 5. This is the `clap` help text, so it also fixes `fqtk demux --help`.
- Correct the same line in the pasted `--help` block in the README, which had inherited the stale text. Verified against real `fqtk demux --help` output after the change.
- Extend `test_too_few_threads_fails` to cover 4 threads via `rstest` cases. The test previously only exercised 2 threads, which is below both the old and the new floor, so it would have passed either way and could not catch this drift. Confirmed the new case is load-bearing: reverting the validation to `< 3` makes it fail.

No behavior change — documentation and test coverage only.